### PR TITLE
run: don't print error with for --help

### DIFF
--- a/xdg-app-builtins-run.c
+++ b/xdg-app-builtins-run.c
@@ -175,14 +175,14 @@ xdg_app_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
         }
     }
 
+  if (!xdg_app_option_context_parse (context, options, &argc, &argv, XDG_APP_BUILTIN_FLAG_NO_DIR, NULL, cancellable, error))
+    goto out;
+
   if (rest_argc == 0)
     {
       usage_error (context, "APP must be specified", error);
       goto out;
     }
-
-  if (!xdg_app_option_context_parse (context, options, &argc, &argv, XDG_APP_BUILTIN_FLAG_NO_DIR, NULL, cancellable, error))
-    goto out;
 
   app = argv[rest_argv_start];
 


### PR DESCRIPTION
This follows what all the other builtins do: first parse the
commandline, then error out if we got too few arguments.