### PR TITLE
Avoid many copies of usage_error function

### DIFF
--- a/xdg-app-builtins-add-repo.c
+++ b/xdg-app-builtins-add-repo.c
@@ -17,14 +17,6 @@ static GOptionEntry options[] = {
   { NULL }
 };
 
-static void
-usage_error (GOptionContext *context, const char *message, GError **error)
-{
-  gs_free gchar *help = g_option_context_get_help (context, TRUE, NULL);
-  g_printerr ("%s", help);
-  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED, message);
-}
-
 gboolean
 xdg_app_builtin_add_repo (int argc, char **argv, GCancellable *cancellable, GError **error)
 {

--- a/xdg-app-builtins-build-init.c
+++ b/xdg-app-builtins-build-init.c
@@ -21,14 +21,6 @@ static GOptionEntry options[] = {
   { NULL }
 };
 
-static void
-usage_error (GOptionContext *context, const char *message, GError **error)
-{
-  gs_free gchar *help = g_option_context_get_help (context, TRUE, NULL);
-  g_printerr ("%s", help);
-  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED, message);
-}
-
 gboolean
 xdg_app_builtin_build_init (int argc, char **argv, GCancellable *cancellable, GError **error)
 {

--- a/xdg-app-builtins-build.c
+++ b/xdg-app-builtins-build.c
@@ -22,14 +22,6 @@ static GOptionEntry options[] = {
   { NULL }
 };
 
-static void
-usage_error (GOptionContext *context, const char *message, GError **error)
-{
-  gs_free gchar *help = g_option_context_get_help (context, TRUE, NULL);
-  g_printerr ("%s", help);
-  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED, message);
-}
-
 gboolean
 xdg_app_builtin_build (int argc, char **argv, GCancellable *cancellable, GError **error)
 {

--- a/xdg-app-builtins-delete-repo.c
+++ b/xdg-app-builtins-delete-repo.c
@@ -8,14 +8,6 @@
 
 #include "xdg-app-builtins.h"
 
-static void
-usage_error (GOptionContext *context, const char *message, GError **error)
-{
-  gs_free gchar *help = g_option_context_get_help (context, TRUE, NULL);
-  g_printerr ("%s", help);
-  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED, message);
-}
-
 gboolean
 xdg_app_builtin_delete_repo (int argc, char **argv, GCancellable *cancellable, GError **error)
 {

--- a/xdg-app-builtins-install.c
+++ b/xdg-app-builtins-install.c
@@ -17,14 +17,6 @@ static GOptionEntry options[] = {
   { NULL }
 };
 
-static void
-usage_error (GOptionContext *context, const char *message, GError **error)
-{
-  gs_free gchar *help = g_option_context_get_help (context, TRUE, NULL);
-  g_printerr ("%s", help);
-  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED, message);
-}
-
 gboolean
 xdg_app_builtin_install_runtime (int argc, char **argv, GCancellable *cancellable, GError **error)
 {

--- a/xdg-app-builtins-run.c
+++ b/xdg-app-builtins-run.c
@@ -24,14 +24,6 @@ static GOptionEntry options[] = {
   { NULL }
 };
 
-static void
-usage_error (GOptionContext *context, const char *message, GError **error)
-{
-  gs_free gchar *help = g_option_context_get_help (context, TRUE, NULL);
-  g_printerr ("%s", help);
-  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED, message);
-}
-
 static char *
 extract_unix_path_from_dbus_addres (const char *address)
 {

--- a/xdg-app-builtins-update.c
+++ b/xdg-app-builtins-update.c
@@ -17,14 +17,6 @@ static GOptionEntry options[] = {
   { NULL }
 };
 
-static void
-usage_error (GOptionContext *context, const char *message, GError **error)
-{
-  gs_free gchar *help = g_option_context_get_help (context, TRUE, NULL);
-  g_printerr ("%s", help);
-  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED, message);
-}
-
 gboolean
 xdg_app_builtin_update_runtime (int argc, char **argv, GCancellable *cancellable, GError **error)
 {

--- a/xdg-app-builtins.h
+++ b/xdg-app-builtins.h
@@ -22,6 +22,10 @@ gboolean xdg_app_option_context_parse (GOptionContext *context,
                                        GCancellable *cancellable,
                                        GError **error);
 
+void usage_error (GOptionContext *context,
+                  const char *message,
+                  GError **error);
+
 #define BUILTINPROTO(name) gboolean xdg_app_builtin_ ## name (int argc, char **argv, GCancellable *cancellable, GError **error)
 
 BUILTINPROTO(add_repo);

--- a/xdg-app-main.c
+++ b/xdg-app-main.c
@@ -153,6 +153,14 @@ xdg_app_option_context_parse (GOptionContext *context,
   return success;
 }
 
+void
+usage_error (GOptionContext *context, const char *message, GError **error)
+{
+  gs_free gchar *help = g_option_context_get_help (context, TRUE, NULL);
+  g_printerr ("%s", help);
+  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED, message);
+}
+
 int
 xdg_app_run (int    argc,
              char **argv,


### PR DESCRIPTION
No need to have the identical static function in every
builtin command.