### PR TITLE
A couple fixes for xdg-app

### DIFF
--- a/xdg-app-helper.c
+++ b/xdg-app-helper.c
@@ -1201,6 +1201,7 @@ main (int argc,
   xsetenv ("LD_LIBRARY_PATH", "/self/lib", 1);
   xsetenv ("XDG_CONFIG_DIRS","/self/etc/xdg:/etc/xdg", 1);
   xsetenv ("XDG_DATA_DIRS", "/self/share:/usr/share", 1);
+  xsetenv ("GI_TYPELIB_PATH", "/self/lib/girepository-1.0", 1);
   xdg_runtime_dir = strdup_printf ("/run/user/%d", getuid());
   xsetenv ("XDG_RUNTIME_DIR", xdg_runtime_dir, 1);
   free (xdg_runtime_dir);

--- a/xdg-app-helper.c
+++ b/xdg-app-helper.c
@@ -260,7 +260,8 @@ static const create_table_t create[] = {
   { FILE_TYPE_SYSTEM_SYMLINK, "lib", 0755, "usr/lib"},
   { FILE_TYPE_SYSTEM_SYMLINK, "bin", 0755, "usr/bin" },
   { FILE_TYPE_SYSTEM_SYMLINK, "sbin", 0755, "usr/sbin"},
-  { FILE_TYPE_SYSTEM_SYMLINK, "etc", 0755, "usr/etc"},
+  { FILE_TYPE_DIR, "etc", 0755 },
+  { FILE_TYPE_BIND_RO, "etc", 0755, "/etc" },
   { FILE_TYPE_DIR, "tmp/.X11-unix", 0755 },
   { FILE_TYPE_REGULAR, "tmp/.X11-unix/X99", 0755 },
   { FILE_TYPE_DIR, "proc", 0755},
@@ -285,8 +286,6 @@ static const create_table_t create[] = {
 };
 
 static const create_table_t create_post[] = {
-  { FILE_TYPE_BIND, "usr/etc/machine-id", 0444, "/etc/machine-id", FILE_FLAGS_NON_FATAL},
-  { FILE_TYPE_BIND, "usr/etc/machine-id", 0444, "/var/lib/dbus/machine-id", FILE_FLAGS_NON_FATAL | FILE_FLAGS_IF_LAST_FAILED},
 };
 
 static const mount_table_t mount_table[] = {
@@ -1096,12 +1095,6 @@ main (int argc,
 
   /* /usr now mounted private inside the namespace, tell child process to unmount the tmpfs in the parent namespace. */
   close (pipefd[WRITE_END]);
-
-  if (bind_mount ("/etc/passwd", "etc/passwd", BIND_READONLY))
-    die_with_error ("mount passwd");
-
-  if (bind_mount ("/etc/group", "etc/group", BIND_READONLY))
-    die_with_error ("mount group");
 
   /* Bind mount in X socket
    * This is a bit iffy, as Xlib typically uses abstract unix domain sockets


### PR DESCRIPTION
Hey cool work!

I tried to run this for a bundled version of gnome-weather, and it didn't work at first.

The only controversial thing is using the host /etc, which fixes localtime and resolv.conf - incidentally two features on which gnome-weather relies - but breaks TLS because the runtime uses /etc/ssl/certs/ca-certificates.crt but the host (Fedora 21 clean install) uses /etc/ssl/certs/ca-bundle.trust.crt (from p11-kit). My hope is that this small differences can be reconciliated through standardization, and it seems better to me than special casing all the files in /etc + losing sysadmin changes.
But if you want we can continue this on the mailing list.