### PR TITLE
Drop the unused --name option for build-init

### DIFF
--- a/doc/xdg-app-build-init.xml
+++ b/doc/xdg-app-build-init.xml
@@ -85,15 +85,6 @@
             </varlistentry>
 
             <varlistentry>
-                <term><option>-n</option></term>
-                <term><option>--name=NAME</option></term>
-
-                <listitem><para>
-                    The application name.
-                </para></listitem>
-            </varlistentry>
-
-            <varlistentry>
                 <term><option>-v</option></term>
                 <term><option>--var=RUNTIME</option></term>
 

--- a/xdg-app-builtins-build-init.c
+++ b/xdg-app-builtins-build-init.c
@@ -11,12 +11,10 @@
 #include "xdg-app-utils.h"
 
 static char *opt_arch;
-static char *opt_name;
 static char *opt_var;
 
 static GOptionEntry options[] = {
   { "arch", 0, 0, G_OPTION_ARG_STRING, &opt_arch, "Arch to use", "ARCH" },
-  { "name", 'n', 0, G_OPTION_ARG_STRING, &opt_name, "App name", "NAME" },
   { "var", 'v', 0, G_OPTION_ARG_STRING, &opt_var, "Initialize var from named runtime", "RUNTIME" },
   { NULL }
 };


### PR DESCRIPTION
It is not used at all.