### PR TITLE
Export gnome-shell search provider files

### DIFF
--- a/xdg-app-builtins-build-finish.c
+++ b/xdg-app-builtins-build-finish.c
@@ -45,9 +45,10 @@ collect_exports (GFile *base, GCancellable *cancellable, GError **error)
   gs_unref_object GFile *files = NULL;
   gs_unref_object GFile *export = NULL;
   const char *paths[] = {
-    "share/applications",    /* Copy desktop files */
-    "share/icons/hicolor",   /* Icons */
-    "share/dbus-1/services", /* D-Bus service files */
+    "share/applications",                 /* Copy desktop files */
+    "share/icons/hicolor",                /* Icons */
+    "share/dbus-1/services",              /* D-Bus service files */
+    "share/gnome-shell/search-providers", /* Search providers */
     NULL,
   };
   int i;


### PR DESCRIPTION
This is meant as a generic extension point that can be used
by 3rd party applications, so we should export these files.
They are needed outside the sandbox, since search is a way
to launch applications.