### PR TITLE
End the console status line after pull

### DIFF
--- a/xdg-app-dir.c
+++ b/xdg-app-dir.c
@@ -256,6 +256,9 @@ xdg_app_dir_pull (XdgAppDir *self,
                          cancellable, error))
     goto out;
 
+  if (console)
+    gs_console_end_status_line (console, NULL, NULL);
+
   ret = TRUE;
  out:
   return ret;


### PR DESCRIPTION
Failure to do so causes the next shell prompt to appear in the
same line as the status, which looks broken.