### PR TITLE
Show the full reference in repo-contents when using --show-details

### DIFF
--- a/xdg-app-builtins-repo-contents.c
+++ b/xdg-app-builtins-repo-contents.c
@@ -173,23 +173,31 @@ xdg_app_builtin_repo_contents (int argc, char **argv, GCancellable *cancellable,
 
       if (g_str_has_prefix (ref, "runtime/") && !opt_only_apps)
         {
-          name = g_strdup (ref + strlen ("runtime/"));
           if (!opt_show_details)
             {
+              name = g_strdup (ref + strlen ("runtime/"));
               p = strchr (name, '/');
               if (p)
                 *p = 0;
+            }
+          else
+            {
+              name = g_strdup (ref);
             }
         }
 
       if (g_str_has_prefix (ref, "app/") && !opt_only_runtimes)
         {
-          name = g_strdup (ref + strlen ("app/"));
           if (!opt_show_details)
             {
+              name = g_strdup (ref + strlen ("app/"));
               p = strchr (name, '/');
               if (p)
                 *p = 0;
+            }
+          else
+            {
+              name = g_strdup (ref);
             }
         }
 


### PR DESCRIPTION
It's useful to know if the ref is an application or a runtime, as each uses a
different command line command.