### PR TITLE
Add a --runtime option to run

### DIFF
--- a/completion/xdg-app
+++ b/completion/xdg-app
@@ -28,12 +28,12 @@ _xdg-app() {
                 [LIST_REMOTES]='--show-urls'
                 [REPO_CONTENTS]='--show-details --runtimes --apps --update'
                 [UNINSTALL]='--keep-ref'
-                [RUN]='--command --branch --devel'
+                [RUN]='--command --branch --devel --runtime'
                 [BUILD_INIT]='--arch --var'
                 [BUILD]='--runtime --network --x11'
                 [BUILD_FINISH]='--command --allow'
                 [BUILD_EXPORT]='--subject --body'
-                [ARG]='--arch --command --branch --var --allow --subject --body'
+                [ARG]='--arch --command --branch --var --allow --subject --body --runtime'
         )
 
         if __contains_word "--user" ${COMP_WORDS[*]}; then
@@ -50,7 +50,7 @@ _xdg-app() {
                         --command)
                                 comps=$(compgen -A command)
                                 ;;
-                        --var)
+                        --var|--runtime)
                                 comps=$(xdg-app $mode list-runtimes)
                                 ;;
                         --allow)


### PR DESCRIPTION
The --runtime option lets us completely override the runtime that
is specified in the application metadata. This is useful for testing
compatibility of an application with runtimes.