### PR TITLE
Quote commandline arguments

### DIFF
--- a/xdg-app-dir.c
+++ b/xdg-app-dir.c
@@ -525,7 +525,7 @@ export_desktop_file (const char    *app,
       g_key_file_remove_key (keyfile, groups[i], "X-GNOME-Bugzilla-ExtraInfoScript", NULL);
 
       new_exec = g_string_new ("");
-      g_string_append_printf (new_exec, XDG_APP_BINDIR"/xdg-app run --branch=%s --arch=%s", branch, arch);
+      g_string_append_printf (new_exec, XDG_APP_BINDIR"/xdg-app run --branch='%s' --arch='%s'", branch, arch);
 
       old_exec = g_key_file_get_string (keyfile, groups[i], "Exec", NULL);
       if (old_exec && g_shell_parse_argv (old_exec, &old_argc, &old_argv, NULL) && old_argc >= 1)
@@ -533,7 +533,7 @@ export_desktop_file (const char    *app,
           int i;
           gs_free char *command = g_shell_quote (old_argv[0]);
 
-          g_string_append_printf (new_exec, " --command=%s", command);
+          g_string_append_printf (new_exec, " --command='%s'", command);
 
           g_string_append (new_exec, " ");
           g_string_append (new_exec, escaped_app);


### PR DESCRIPTION
We don't expect branch or arch names to contain spaces. But if
they do, we should not fall over needlessly.