### PR TITLE
Remove dead code

### DIFF
--- a/xdg-app-builtins-build-finish.c
+++ b/xdg-app-builtins-build-finish.c
@@ -335,9 +335,6 @@ xdg_app_builtin_build_finish (int argc, char **argv, GCancellable *cancellable, 
   g_autoptr(GFile) base = NULL;
   g_autoptr(GFile) files_dir = NULL;
   g_autoptr(GFile) export_dir = NULL;
-  g_autoptr(GFile) var_dir = NULL;
-  g_autoptr(GFile) var_tmp_dir = NULL;
-  g_autoptr(GFile) var_run_dir = NULL;
   g_autoptr(GFile) metadata_file = NULL;
   g_autoptr(XdgAppDir) user_dir = NULL;
   g_autoptr(XdgAppDir) system_dir = NULL;
@@ -364,9 +361,6 @@ xdg_app_builtin_build_finish (int argc, char **argv, GCancellable *cancellable, 
 
   files_dir = g_file_get_child (base, "files");
   export_dir = g_file_get_child (base, "export");
-  var_dir = g_file_get_child (base, "var");
-  var_tmp_dir = g_file_get_child (var_dir, "tmp");
-  var_run_dir = g_file_get_child (var_dir, "run");
   metadata_file = g_file_get_child (base, "metadata");
 
   if (!g_file_query_exists (files_dir, cancellable) ||

--- a/xdg-app-builtins-build-init.c
+++ b/xdg-app-builtins-build-init.c
@@ -55,8 +55,6 @@ xdg_app_builtin_build_init (int argc, char **argv, GCancellable *cancellable, GE
   g_autoptr(GFile) var_tmp_dir = NULL;
   g_autoptr(GFile) var_run_dir = NULL;
   g_autoptr(GFile) metadata_file = NULL;
-  g_autoptr(XdgAppDir) user_dir = NULL;
-  g_autoptr(XdgAppDir) system_dir = NULL;
   const char *app_id;
   const char *directory;
   const char *sdk;
@@ -131,9 +129,6 @@ xdg_app_builtin_build_init (int argc, char **argv, GCancellable *cancellable, GE
 
   if (opt_var)
     {
-      user_dir = xdg_app_dir_get_user ();
-      system_dir = xdg_app_dir_get_system ();
-
       var_ref = xdg_app_build_runtime_ref (opt_var, branch, opt_arch);
 
       var_deploy_base = xdg_app_find_deploy_dir_for_ref (var_ref, cancellable, error);

--- a/xdg-app-dir.c
+++ b/xdg-app-dir.c
@@ -627,12 +627,9 @@ xdg_app_dir_run_triggers (XdgAppDir *self,
   g_autoptr(GFileEnumerator) dir_enum = NULL;
   g_autoptr(GFileInfo) child_info = NULL;
   g_autoptr(GFile) triggersdir = NULL;
-  g_autoptr(GFile) exports = NULL;
   GError *temp_error = NULL;
 
   g_debug ("running triggers");
-
-  exports = xdg_app_dir_get_exports_dir (self);
 
   triggersdir = g_file_new_for_path (XDG_APP_TRIGGERDIR);
 
@@ -1180,7 +1177,6 @@ xdg_app_dir_deploy (XdgAppDir *self,
   g_autoptr(GFile) checkoutdir = NULL;
   g_autoptr(GFile) dotref = NULL;
   g_autoptr(GFile) export = NULL;
-  g_autoptr(GFile) exports = NULL;
 
   if (!xdg_app_dir_ensure_repo (self, cancellable, error))
     goto out;
@@ -1281,7 +1277,6 @@ xdg_app_dir_deploy (XdgAppDir *self,
                                 G_FILE_CREATE_NONE, NULL, cancellable, error))
     goto out;
 
-  exports = xdg_app_dir_get_exports_dir (self);
   export = g_file_get_child (checkoutdir, "export");
   if (g_file_query_exists (export, cancellable))
     {


### PR DESCRIPTION
Remove some dead code found while reading up on the code base and exposing it to clang's scan-build.