### PR TITLE
Fix path generation when recursively exporting a directory

### DIFF
--- a/xdg-app-builtins-build-finish.c
+++ b/xdg-app-builtins-build-finish.c
@@ -103,7 +103,7 @@ export_dir (int            source_parent_fd,
 
       if (S_ISDIR (stbuf.st_mode))
         {
-          g_autofree gchar *child_relpath = g_strconcat (source_relpath, dent->d_name, "/", NULL);
+          g_autofree gchar *child_relpath = g_build_filename(source_relpath, dent->d_name, NULL);
 
           if (!export_dir (source_iter.fd, dent->d_name, child_relpath, destination_dfd, dent->d_name,
                            required_prefix, cancellable, error))


### PR DESCRIPTION
It is not guaranteed that source_relpath ends with '/', so g_strconcat()
would generate invalid path, like "share/icons/hicolor64x64/apps". Use
g_build_filename() instead to ensure we don't miss any separators.