### PR TITLE
build: Fix srcdir != builddir from git

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -148,9 +148,9 @@ completion_DATA = completion/xdg-app
 EXTRA_DIST += $(completion_DATA)
 
 profiledir = $(sysconfdir)/profile.d
-profile_DATA = profile/xdg-app.sh
+profile_DATA = xdg-app.sh
 EXTRA_DIST += profile/xdg-app.sh.in
 
-profile/xdg-app.sh: profile/xdg-app.sh.in
+xdg-app.sh: profile/xdg-app.sh.in
 	$(AM_V_GEN) $(SED) -e "s|\@localstatedir\@|$(localstatedir)|" \
 		-e "s|\@sysconfdir\@|$(sysconfdir)|" $< > $@


### PR DESCRIPTION
We could just `mkdir -p profile`, but it's saner to just drop it in
the builddir.