### PR TITLE
xdg-app-utils: Correct SoupUri -> SoupURI typo.

### DIFF
--- a/common/xdg-app-utils.h
+++ b/common/xdg-app-utils.h
@@ -169,7 +169,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(OstreeGpgVerifyResult, g_object_unref)
 #ifndef SOUP_AUTOCLEANUPS_H
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(SoupSession, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(SoupMessage, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(SoupUri, soup_uri_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(SoupURI, soup_uri_free)
 #endif
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(XdgAppSessionHelper, g_object_unref)


### PR DESCRIPTION
It should be SoupURI, not SoupUri:
https://developer.gnome.org/libsoup/stable/SoupURI.html#soup-uri-new

This broke the build for me.