### PR TITLE
builder: Better message when icon dir not found

### DIFF
--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -940,8 +940,17 @@ builder_manifest_cleanup (BuilderManifest *self,
         {
           g_autoptr(GFile) icons_dir = g_file_resolve_relative_path (app_root, "share/icons");
 
-          if (!foreach_file (self, rename_icon_cb, icons_dir, error))
+          GError *error_foreach = NULL;
+          if (!foreach_file (self, rename_icon_cb, icons_dir, &error_foreach)) {
+            char *path = g_file_get_path (icons_dir);
+            g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+              "foreach_file() failed with icons_dir path: %s with error: %s",
+              path, error_foreach->message);
+            g_free (path);
+            g_clear_error (&error_foreach);
+
             return FALSE;
+          }
         }
 
       if (self->rename_icon ||


### PR DESCRIPTION
Otherwise, you just see this cryptic error message:
  error: openat: No such file or directory
This way you see the directory path that couldn't be found,
giving you some clue about what xdg-app-builder was trying to do.

However, doing this everywhere that you catch a GError would add huge amounts of tedious code, so I'd understand if you'd rather not go down this road. Maybe it's OK to directly free and set the GError::message string instead, though that feels wrong. This kind of things is a bit easier in C++ or Java.

I also (or instead) added the path to the underlying libglnx GError message: https://github.com/GNOME/libglnx/pull/11