### PR TITLE
Builddir != srcdir fixes

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -18,7 +18,6 @@ fi
 # regenerated from their corresponding *.in files by ./configure anyway.
 touch INSTALL
 
-cd "$olddir"
 if ! test -f libglnx/README.md; then
     git submodule update --init
 fi
@@ -27,4 +26,5 @@ sed -e 's,$(libglnx_srcpath),'${srcdir}/libglnx,g < libglnx/Makefile-libglnx.am 
 
 autoreconf --force --install --verbose || exit $?
 
+cd "$olddir"
 test -n "$NOCONFIGURE" || "$srcdir/configure" "$@"

--- a/lib/Makefile.am.inc
+++ b/lib/Makefile.am.inc
@@ -53,7 +53,8 @@ libxdg_app_la_SOURCES = \
 libxdg_app_la_CFLAGS = \
 	$(HIDDEN_VISIBILITY_CFLAGS)		\
 	-DXDG_APP_COMPILATION \
-	-I$(srcdir)/lib \
+	-I$(top_srcdir)/lib \
+	-I$(top_builddir)/lib \
 	$(AM_CFLAGS) \
 	$(BASE_CFLAGS) \
 	$(OSTREE_CFLAGS) \
@@ -79,7 +80,8 @@ test_libxdg_app_SOURCES = \
 
 test_libxdg_app_CFLAGS = \
 	$(BASE_CFLAGS) \
-	-I$(srcdir)/lib \
+	-I$(top_srcdir)/lib \
+	-I$(top_builddir)/lib \
 	$(NULL)
 
 test_libxdg_app_LDADD = \


### PR DESCRIPTION
Simple build fixes that allow configuring and building xdg-app in a separate directory.