### PR TITLE
xdg_app_builtin_add_remote(): Try importing gpg keys first.

### DIFF
--- a/app/xdg-app-builtins-add-remote.c
+++ b/app/xdg-app-builtins-add-remote.c
@@ -168,6 +168,9 @@ xdg_app_builtin_add_remote (int argc, char **argv,
   remote_name = argv[1];
   url_or_path  = argv[2];
 
+  if (!import_keys (dir, remote_name, cancellable, error))
+    return FALSE;
+
   file = g_file_new_for_commandline_arg (url_or_path);
   if (g_file_is_native (file))
     remote_url = g_file_get_uri (file);
@@ -224,8 +227,7 @@ xdg_app_builtin_add_remote (int argc, char **argv,
         }
     }
 
-  if (!import_keys (dir, remote_name, cancellable, error))
-    return FALSE;
+
 
   return TRUE;
 }


### PR DESCRIPTION
It seems wise to check local files before checking remote files.
Then we can fail more quickly.
And this stops us from adding a remote repository even when the
specified gpg key could not be found:
https://github.com/alexlarsson/xdg-app/issues/92

However, I guess that it would be nice to roll back the gpg import if the later steps fail. And it would be nice to roll back the later steps if the last check fails.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/alexlarsson/xdg-app/94)

<!-- Reviewable:end -->
