### PR TITLE
builder: Don't delete the APPDIR directory

### DIFF
--- a/builder/builder-utils.c
+++ b/builder/builder-utils.c
@@ -219,3 +219,19 @@ gboolean is_elf_file (const char *path,
 
   return FALSE;
 }
+
+gboolean directory_is_empty (const char *path)
+{
+  GDir *dir;
+  gboolean empty;
+
+  dir = g_dir_open (path, 0, NULL);
+  if (g_dir_read_name (dir) == NULL)
+    empty = TRUE;
+  else
+    empty = FALSE;
+
+  g_dir_close (dir);
+
+  return empty;
+}

--- a/builder/builder-utils.h
+++ b/builder/builder-utils.h
@@ -37,6 +37,8 @@ gboolean is_elf_file (const char *path,
                       gboolean *is_shared,
                       gboolean *is_stripped);
 
+gboolean directory_is_empty (const char *path);
+
 gboolean xdg_app_matches_path_pattern             (const char *path,
                                                    const char *pattern);
 void     xdg_app_collect_matches_for_path_pattern (const char *path,

--- a/builder/xdg-app-builder-main.c
+++ b/builder/xdg-app-builder-main.c
@@ -30,6 +30,7 @@
 #include "libgsystem.h"
 
 #include "builder-manifest.h"
+#include "builder-utils.h"
 
 static gboolean opt_verbose;
 static gboolean opt_version;
@@ -210,9 +211,10 @@ main (int    argc,
   base_dir = g_file_new_for_path (g_get_current_dir ());
   app_dir = g_file_new_for_path (app_dir_path);
 
-  if (!gs_shutil_rm_rf (app_dir, NULL, &error))
+  if (g_file_query_exists (app_dir, NULL) && !directory_is_empty (app_dir_path))
     {
-      g_print ("error removing old app dir '%s': %s\n", app_dir_path, error->message);
+      g_printerr ("App dir '%s' is not empty. Please delete "
+                  "the existing contents.\n", app_dir_path);
       return 1;
     }
 


### PR DESCRIPTION
A new user might think that APPDIR is the location of the app to be
built, and run something like `xdg-app-builder . ./manifest`. This
could silently the user's entire project that they are trying to
package, which is not acceptable at all! Even if you think it is their
fault for not reading the manual first!

This commit means that APPDIR is no longer deleted. Instead,
xdg-app-builder checks whether it is empty and, if it is not, it asks
the user to delete the contents and then rerun it.

This means you now have to do `rm -Rf APPDIR; xdg-app-builder APPDIR
MANIFEST` when developing your manifest, but I think that's better than
having a build tool that can optionally delete your whole project.