### PR TITLE
Some more doc improvements for libxdg-app

### DIFF
--- a/doc/reference/gtkdoc-scan.log
+++ b/doc/reference/gtkdoc-scan.log
@@ -1,0 +1,736 @@
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:218: trace: Scanning source directory: ../../lib
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:316: trace: File ignored: ../../lib/xdg-app-remote-private.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:330: trace: Scanning ../../lib/xdg-app-error.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:415: trace: Found start of comment:  xdg-app-error.c
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Copyright (C) 2015 Red Hat, Inc
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This file is free software; you can redistribute it and/or modify it
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * under the terms of the GNU Lesser General Public License as
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * published by the Free Software Foundation; either version 2 of the
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License, or (at your option) any later version.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This file is distributed in the hope that it will be useful, but
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * WITHOUT ANY WARRANTY; without even the implied warranty of
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Lesser General Public License for more details.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * You should have received a copy of the GNU Lesser General Public License
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Authors:
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *       Alexander Larsson <alexl@redhat.com>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #ifndef XDG_APP_ERROR_H
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_ERROR_H
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:442: trace: skipping Macro: XDG_APP_ERROR_H
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <glib.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: G_BEGIN_DECLS
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:415: trace: Found start of comment: *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * XdpErrorEnum:
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: typedef enum {
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:509: trace: typedef enum: -
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   XDG_APP_ERROR_ALREADY_INSTALLED,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   XDG_APP_ERROR_NOT_INSTALLED,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0] } XdgAppError;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_ERROR xdg_app_error_quark()
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_ERROR
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: GQuark  xdg_app_error_quark      (void);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:617: trace: Function (1): xdg_app_error_quark, Returns: [GQuark][  ]
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:781: trace: zzzFunction void);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:794: trace: Is this a get-type?: [GQuark   ] [xdg_app_error_quark] [void]
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: G_END_DECLS
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif /* XDG_APP_ERROR_H */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:896: trace: Scanning ../../lib/xdg-app-error.h done
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:330: trace: Scanning ../../lib/xdg-app.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:415: trace: Found start of comment: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Copyright © 2015 Red Hat, Inc
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This program is free software; you can redistribute it and/or
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * modify it under the terms of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License as published by the Free Software Foundation; either
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * version 2 of the License, or (at your option) any later version.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This library is distributed in the hope that it will be useful,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Lesser General Public License for more details.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * You should have received a copy of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Authors:
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *       Alexander Larsson <alexl@redhat.com>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #ifndef __XDG_APP_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define __XDG_APP_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:442: trace: skipping Macro: __XDG_APP_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define __XDG_APP_H_INSIDE__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:442: trace: skipping Macro: __XDG_APP_H_INSIDE__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <gio/gio.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <xdg-app-version-macros.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <xdg-app-enum-types.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <xdg-app-error.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <xdg-app-ref.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <xdg-app-installed-ref.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <xdg-app-remote-ref.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <xdg-app-remote.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <xdg-app-installation.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #undef __XDG_APP_H_INSIDE__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif /* __XDG_APP_H__ */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:896: trace: Scanning ../../lib/xdg-app.h done
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:330: trace: Scanning ../../lib/xdg-app-remote-ref.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:415: trace: Found start of comment: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Copyright © 2015 Red Hat, Inc
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This program is free software; you can redistribute it and/or
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * modify it under the terms of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License as published by the Free Software Foundation; either
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * version 2 of the License, or (at your option) any later version.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This library is distributed in the hope that it will be useful,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Lesser General Public License for more details.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * You should have received a copy of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Authors:
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *       Alexander Larsson <alexl@redhat.com>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #if !defined (__XDG_APP_H_INSIDE__) && !defined (XDG_APP_COMPILATION)
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #error "Only <xdg-app.h> can be included remote_refectly."
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #ifndef __XDG_APP_REMOTE_REF_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define __XDG_APP_REMOTE_REF_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:442: trace: skipping Macro: __XDG_APP_REMOTE_REF_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: typedef struct XdgAppRemoteRef XdgAppRemoteRef;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:547: trace: Found struct/union(*) typedef XdgAppRemoteRef: typedef struct XdgAppRemoteRef XdgAppRemoteRef;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <gio/gio.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <xdg-app-ref.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_TYPE_REMOTE_REF xdg_app_remote_ref_get_type()
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_TYPE_REMOTE_REF
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_REMOTE_REF(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), XDG_APP_TYPE_REMOTE_REF, XdgAppRemoteRef))
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_REMOTE_REF
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_IS_REMOTE_REF(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XDG_APP_TYPE_REMOTE_REF))
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_IS_REMOTE_REF
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN GType xdg_app_remote_ref_get_type (void);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: struct XdgAppRemoteRef {
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:710: trace: Struct(_): XdgAppRemoteRef
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   XdgAppRef parent;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0] };
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:861: trace: Store struct: XdgAppRemoteRef
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: typedef struct {
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:542: trace: typedef struct/union struct
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   XdgAppRefClass parent_class;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0] } XdgAppRemoteRefClass;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:857: trace: Found object: XdgAppRemoteRef
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:861: trace: Store struct: XdgAppRemoteRefClass
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN const char * xdg_app_remote_ref_get_remote_name (XdgAppRemoteRef *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: G_DEFINE_AUTOPTR_CLEANUP_FUNC(XdgAppRemoteRef, g_object_unref)
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif /* __XDG_APP_REMOTE_REF_H__ */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:896: trace: Scanning ../../lib/xdg-app-remote-ref.h done
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:915: trace: Found gobject type 'XDG_APP_REMOTE_REF' from is_ macro
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:935: trace:   Hide instance docs for xdg_appremoteref
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:939: trace:   Hide class docs for xdg_appremoteref
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:943: trace:   Hide iface docs for xdg_appremoteref
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:947: trace:   Hide iface docs for xdg_appremoteref
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:963: trace: Decl '<TITLE>XdgAppRemoteRef</TITLE>,XdgAppRemoteRef,XdgAppRemoteRefClass'
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:964: trace: Std  'XDG_APP_IS_REMOTE_REF,XDG_APP_TYPE_REMOTE_REF,XDG_APP_REMOTE_REF'
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:330: trace: Scanning ../../lib/xdg-app-version-macros.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:415: trace: Found start of comment: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Copyright © 2015 Red Hat, Inc
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This program is free software; you can redistribute it and/or
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * modify it under the terms of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License as published by the Free Software Foundation; either
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * version 2 of the License, or (at your option) any later version.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This library is distributed in the hope that it will be useful,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Lesser General Public License for more details.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * You should have received a copy of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Authors:
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *       Alexander Larsson <alexl@redhat.com>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #if !defined (__XDG_APP_H_INSIDE__) && !defined (XDG_APP_COMPILATION)
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #error "Only <xdg-app.h> can be included directly."
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #ifndef __XDG_APP_VERSION_MACROS_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define __XDG_APP_VERSION_MACROS_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:442: trace: skipping Macro: __XDG_APP_VERSION_MACROS_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_MAJOR_VERSION (0)
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_MAJOR_VERSION
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_MINOR_VERSION (4)
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_MINOR_VERSION
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_MICRO_VERSION (7)
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_MICRO_VERSION
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #ifndef XDG_APP_EXTERN
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_EXTERN extern
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_EXTERN
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif /* __XDG_APP_VERSION_MACROS_H__ */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:896: trace: Scanning ../../lib/xdg-app-version-macros.h done
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:316: trace: File ignored: ../../lib/xdg-app-enum-types.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:330: trace: Scanning ../../lib/xdg-app-remote-ref-private.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:415: trace: Found start of comment: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Copyright © 2015 Red Hat, Inc
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This program is free software; you can redistribute it and/or
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * modify it under the terms of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License as published by the Free Software Foundation; either
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * version 2 of the License, or (at your option) any later version.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This library is distributed in the hope that it will be useful,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Lesser General Public License for more details.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * You should have received a copy of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Authors:
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *       Alexander Larsson <alexl@redhat.com>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #if !defined (__XDG_APP_H_INSIDE__) && !defined (XDG_APP_COMPILATION)
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #error "Only <xdg-app.h> can be included remote_refectly."
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #ifndef __XDG_APP_REMOTE_REF_PRIVATE_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define __XDG_APP_REMOTE_REF_PRIVATE_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:442: trace: skipping Macro: __XDG_APP_REMOTE_REF_PRIVATE_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <xdg-app-remote-ref.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <xdg-app-dir.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XdgAppRemoteRef *xdg_app_remote_ref_new (const char *full_ref,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:617: trace: Function (1): xdg_app_remote_ref_new, Returns: [XdgAppRemoteRef][ *]
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:781: trace: zzzFunction const char *full_ref,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]                                          const char *commit,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:781: trace: zzzFunction const char *full_ref,
+                                         const char *commit,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]                                          const char *remote_name);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:781: trace: zzzFunction const char *full_ref,
+                                         const char *commit,
+                                         const char *remote_name);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:794: trace: Is this a get-type?: [XdgAppRemoteRef  *] [xdg_app_remote_ref_new] [const char *full_ref, const char *commit, const char *remote_name]
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif /* __XDG_APP_REMOTE_REF_PRIVATE_H__ */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:896: trace: Scanning ../../lib/xdg-app-remote-ref-private.h done
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:330: trace: Scanning ../../lib/xdg-app-installation.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:415: trace: Found start of comment: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Copyright © 2015 Red Hat, Inc
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This program is free software; you can redistribute it and/or
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * modify it under the terms of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License as published by the Free Software Foundation; either
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * version 2 of the License, or (at your option) any later version.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This library is distributed in the hope that it will be useful,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Lesser General Public License for more details.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * You should have received a copy of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Authors:
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *       Alexander Larsson <alexl@redhat.com>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #if !defined (__XDG_APP_H_INSIDE__) && !defined (XDG_APP_COMPILATION)
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #error "Only <xdg-app.h> can be included installationectly."
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #ifndef __XDG_APP_INSTALLATION_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define __XDG_APP_INSTALLATION_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:442: trace: skipping Macro: __XDG_APP_INSTALLATION_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: typedef struct XdgAppInstallation XdgAppInstallation;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:547: trace: Found struct/union(*) typedef XdgAppInstallation: typedef struct XdgAppInstallation XdgAppInstallation;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <gio/gio.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <xdg-app-installed-ref.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <xdg-app-remote.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_TYPE_INSTALLATION xdg_app_installation_get_type()
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_TYPE_INSTALLATION
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_INSTALLATION(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), XDG_APP_TYPE_INSTALLATION, XdgAppInstallation))
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_INSTALLATION
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_IS_INSTALLATION(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XDG_APP_TYPE_INSTALLATION))
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_IS_INSTALLATION
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: GType xdg_app_installation_get_type (void);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:617: trace: Function (1): xdg_app_installation_get_type, Returns: [GType][ ]
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:781: trace: zzzFunction void);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:794: trace: Is this a get-type?: [GType  ] [xdg_app_installation_get_type] [void]
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:796: trace: Adding get-type: [GType  ] [xdg_app_installation_get_type] [void]	from ../../lib/xdg-app-installation.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: struct XdgAppInstallation {
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:710: trace: Struct(_): XdgAppInstallation
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   GObject parent;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0] };
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:861: trace: Store struct: XdgAppInstallation
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: typedef struct {
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:542: trace: typedef struct/union struct
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   GObjectClass parent_class;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0] } XdgAppInstallationClass;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:857: trace: Found object: XdgAppInstallation
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:861: trace: Store struct: XdgAppInstallationClass
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: typedef enum {
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:509: trace: typedef enum: -
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   XDG_APP_UPDATE_FLAGS_NONE      = 0,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   XDG_APP_UPDATE_FLAGS_NO_DEPLOY = (1<<0),
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   XDG_APP_UPDATE_FLAGS_NO_PULL   = (1<<1),
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0] } XdgAppUpdateFlags;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: G_DEFINE_AUTOPTR_CLEANUP_FUNC(XdgAppInstallation, g_object_unref)
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN XdgAppInstallation *xdg_app_installation_new_system (GCancellable *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                     GError **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN XdgAppInstallation *xdg_app_installation_new_user (GCancellable *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                   GError **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN XdgAppInstallation *xdg_app_installation_new_for_path (GFile *path,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                       gboolean user,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                       GCancellable *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                       GError **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: typedef void (*XdgAppProgressCallback)(const char *status,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:458: trace: user function (1): XdgAppProgressCallback, Returns: void 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]                                        guint progress,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]                                        gboolean estimating,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]                                        gpointer user_data);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN gboolean             xdg_app_installation_get_is_user               (XdgAppInstallation  *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN gboolean             xdg_app_installation_launch                    (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *name,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *arch,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *branch,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *commit,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN GFileMonitor        *xdg_app_installation_create_monitor            (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN GPtrArray           *xdg_app_installation_list_installed_refs       (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN GPtrArray           *xdg_app_installation_list_installed_refs_by_kind (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     XdgAppRefKind        kind,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN GPtrArray           *xdg_app_installation_list_installed_refs_for_update (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                          GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                          GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN XdgAppInstalledRef * xdg_app_installation_get_installed_ref         (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     XdgAppRefKind        kind,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *name,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *arch,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *branch,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN XdgAppInstalledRef * xdg_app_installation_get_current_installed_app (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *name,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN GPtrArray           *xdg_app_installation_list_remotes              (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN char *              xdg_app_installation_load_app_overrides         (XdgAppInstallation *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char         *app_id,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GCancellable       *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GError            **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN XdgAppInstalledRef * xdg_app_installation_install                   (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *remote_name,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     XdgAppRefKind        kind,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *name,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *arch,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *branch,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     XdgAppProgressCallback  progress,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     gpointer             progress_data,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN XdgAppInstalledRef * xdg_app_installation_update                    (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     XdgAppUpdateFlags    flags,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     XdgAppRefKind        kind,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *name,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *arch,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *branch,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     XdgAppProgressCallback  progress,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     gpointer             progress_data,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN gboolean             xdg_app_installation_uninstall                 (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     XdgAppRefKind        kind,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *name,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *arch,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     const char          *branch,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     XdgAppProgressCallback  progress,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     gpointer             progress_data,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                     GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN gboolean          xdg_app_installation_fetch_remote_size_sync     (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   const char          *remote_name,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   const char          *commit,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   guint64             *download_size,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   guint64             *installed_size,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN GBytes        *   xdg_app_installation_fetch_remote_metadata_sync (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   const char          *remote_name,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   const char          *commit,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN GPtrArray    *    xdg_app_installation_list_remote_refs_sync      (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   const char          *remote_name,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN XdgAppRemoteRef  *xdg_app_installation_fetch_remote_ref_sync      (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   const char          *remote_name,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   XdgAppRefKind        kind,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   const char          *name,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   const char          *arch,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   const char          *branch,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN gboolean          xdg_app_installation_update_appstream_sync      (XdgAppInstallation  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   const char          *remote_name,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   const char          *arch,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   gboolean            *out_changed,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                                   GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif /* __XDG_APP_INSTALLATION_H__ */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:896: trace: Scanning ../../lib/xdg-app-installation.h done
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:915: trace: Found gobject type 'XDG_APP_INSTALLATION' from is_ macro
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:935: trace:   Hide instance docs for xdg_appinstallation
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:939: trace:   Hide class docs for xdg_appinstallation
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:943: trace:   Hide iface docs for xdg_appinstallation
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:947: trace:   Hide iface docs for xdg_appinstallation
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:963: trace: Decl '<TITLE>XdgAppInstallation</TITLE>,XdgAppInstallation,XdgAppInstallationClass,XdgAppUpdateFlags,XdgAppProgressCallback'
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:964: trace: Std  'XDG_APP_IS_INSTALLATION,XDG_APP_TYPE_INSTALLATION,xdg_app_installation_get_type,XDG_APP_INSTALLATION'
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:330: trace: Scanning ../../lib/xdg-app-remote.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:415: trace: Found start of comment: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Copyright © 2015 Red Hat, Inc
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This program is free software; you can redistribute it and/or
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * modify it under the terms of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License as published by the Free Software Foundation; either
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * version 2 of the License, or (at your option) any later version.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This library is distributed in the hope that it will be useful,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Lesser General Public License for more details.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * You should have received a copy of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Authors:
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *       Alexander Larsson <alexl@redhat.com>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #if !defined (__XDG_APP_H_INSIDE__) && !defined (XDG_APP_COMPILATION)
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #error "Only <xdg-app.h> can be included remoteectly."
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #ifndef __XDG_APP_REMOTE_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define __XDG_APP_REMOTE_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:442: trace: skipping Macro: __XDG_APP_REMOTE_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: typedef struct XdgAppRemote XdgAppRemote;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:547: trace: Found struct/union(*) typedef XdgAppRemote: typedef struct XdgAppRemote XdgAppRemote;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <gio/gio.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <xdg-app-remote-ref.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_TYPE_REMOTE xdg_app_remote_get_type()
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_TYPE_REMOTE
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_REMOTE(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), XDG_APP_TYPE_REMOTE, XdgAppRemote))
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_REMOTE
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_IS_REMOTE(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XDG_APP_TYPE_REMOTE))
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_IS_REMOTE
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN GType xdg_app_remote_get_type (void);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: struct XdgAppRemote {
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:710: trace: Struct(_): XdgAppRemote
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   GObject parent;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0] };
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:861: trace: Store struct: XdgAppRemote
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: typedef struct {
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:542: trace: typedef struct/union struct
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   GObjectClass parent_class;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0] } XdgAppRemoteClass;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:857: trace: Found object: XdgAppRemote
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:861: trace: Store struct: XdgAppRemoteClass
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: G_DEFINE_AUTOPTR_CLEANUP_FUNC(XdgAppRemote, g_object_unref)
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN const char *  xdg_app_remote_get_name          (XdgAppRemote *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN GFile *       xdg_app_remote_get_appstream_dir (XdgAppRemote *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                const char   *arch);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN GFile *       xdg_app_remote_get_appstream_timestamp (XdgAppRemote *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                      const char   *arch);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN char *        xdg_app_remote_get_url           (XdgAppRemote *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN char *        xdg_app_remote_get_title         (XdgAppRemote *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN gboolean      xdg_app_remote_get_gpg_verify    (XdgAppRemote *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN gboolean      xdg_app_remote_get_noenumerate   (XdgAppRemote *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN int           xdg_app_remote_get_prio          (XdgAppRemote *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif /* __XDG_APP_REMOTE_H__ */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:896: trace: Scanning ../../lib/xdg-app-remote.h done
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:915: trace: Found gobject type 'XDG_APP_REMOTE' from is_ macro
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:935: trace:   Hide instance docs for xdg_appremote
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:939: trace:   Hide class docs for xdg_appremote
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:943: trace:   Hide iface docs for xdg_appremote
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:947: trace:   Hide iface docs for xdg_appremote
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:963: trace: Decl '<TITLE>XdgAppRemote</TITLE>,XdgAppRemote,XdgAppRemoteClass'
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:964: trace: Std  'XDG_APP_IS_REMOTE,XDG_APP_TYPE_REMOTE,XDG_APP_REMOTE'
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:316: trace: File ignored: ../../lib/xdg-app-installed-ref-private.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:330: trace: Scanning ../../lib/xdg-app-installed-ref.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:415: trace: Found start of comment: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Copyright © 2015 Red Hat, Inc
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This program is free software; you can redistribute it and/or
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * modify it under the terms of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License as published by the Free Software Foundation; either
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * version 2 of the License, or (at your option) any later version.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This library is distributed in the hope that it will be useful,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Lesser General Public License for more details.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * You should have received a copy of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Authors:
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *       Alexander Larsson <alexl@redhat.com>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #if !defined (__XDG_APP_H_INSIDE__) && !defined (XDG_APP_COMPILATION)
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #error "Only <xdg-app.h> can be included installed_refectly."
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #ifndef __XDG_APP_INSTALLED_REF_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define __XDG_APP_INSTALLED_REF_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:442: trace: skipping Macro: __XDG_APP_INSTALLED_REF_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: typedef struct XdgAppInstalledRef XdgAppInstalledRef;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:547: trace: Found struct/union(*) typedef XdgAppInstalledRef: typedef struct XdgAppInstalledRef XdgAppInstalledRef;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <gio/gio.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <xdg-app-ref.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_TYPE_INSTALLED_REF xdg_app_installed_ref_get_type()
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_TYPE_INSTALLED_REF
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_INSTALLED_REF(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), XDG_APP_TYPE_INSTALLED_REF, XdgAppInstalledRef))
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_INSTALLED_REF
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_IS_INSTALLED_REF(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XDG_APP_TYPE_INSTALLED_REF))
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_IS_INSTALLED_REF
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN GType xdg_app_installed_ref_get_type (void);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: struct XdgAppInstalledRef {
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:710: trace: Struct(_): XdgAppInstalledRef
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   XdgAppRef parent;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0] };
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:861: trace: Store struct: XdgAppInstalledRef
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: typedef struct {
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:542: trace: typedef struct/union struct
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   XdgAppRefClass parent_class;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0] } XdgAppInstalledRefClass;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:857: trace: Found object: XdgAppInstalledRef
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:861: trace: Store struct: XdgAppInstalledRefClass
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: G_DEFINE_AUTOPTR_CLEANUP_FUNC(XdgAppInstalledRef, g_object_unref)
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN const char *xdg_app_installed_ref_get_origin         (XdgAppInstalledRef  *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN guint64     xdg_app_installed_ref_get_installed_size (XdgAppInstalledRef  *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN const char *xdg_app_installed_ref_get_deploy_dir     (XdgAppInstalledRef  *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN const char *xdg_app_installed_ref_get_latest_commit  (XdgAppInstalledRef  *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN gboolean    xdg_app_installed_ref_get_is_current     (XdgAppInstalledRef  *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN char       *xdg_app_installed_ref_load_metadata      (XdgAppInstalledRef  *self,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                      GCancellable        *cancellable,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                                      GError             **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif /* __XDG_APP_INSTALLED_REF_H__ */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:896: trace: Scanning ../../lib/xdg-app-installed-ref.h done
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:915: trace: Found gobject type 'XDG_APP_INSTALLED_REF' from is_ macro
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:935: trace:   Hide instance docs for xdg_appinstalledref
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:939: trace:   Hide class docs for xdg_appinstalledref
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:943: trace:   Hide iface docs for xdg_appinstalledref
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:947: trace:   Hide iface docs for xdg_appinstalledref
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:963: trace: Decl '<TITLE>XdgAppInstalledRef</TITLE>,XdgAppInstalledRef,XdgAppInstalledRefClass'
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:964: trace: Std  'XDG_APP_IS_INSTALLED_REF,XDG_APP_TYPE_INSTALLED_REF,XDG_APP_INSTALLED_REF'
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:330: trace: Scanning ../../lib/xdg-app-ref.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:415: trace: Found start of comment: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Copyright © 2015 Red Hat, Inc
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This program is free software; you can redistribute it and/or
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * modify it under the terms of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License as published by the Free Software Foundation; either
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * version 2 of the License, or (at your option) any later version.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * This library is distributed in the hope that it will be useful,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Lesser General Public License for more details.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * You should have received a copy of the GNU Lesser General Public
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  * Authors:
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  *       Alexander Larsson <alexl@redhat.com>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:343: trace: Comment:  */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #if !defined (__XDG_APP_H_INSIDE__) && !defined (XDG_APP_COMPILATION)
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #error "Only <xdg-app.h> can be included refectly."
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #ifndef __XDG_APP_REF_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define __XDG_APP_REF_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:442: trace: skipping Macro: __XDG_APP_REF_H__
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: typedef struct XdgAppRef XdgAppRef;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:547: trace: Found struct/union(*) typedef XdgAppRef: typedef struct XdgAppRef XdgAppRef;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #include <glib-object.h>
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_TYPE_REF xdg_app_ref_get_type()
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_TYPE_REF
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_REF(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), XDG_APP_TYPE_REF, XdgAppRef))
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_REF
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #define XDG_APP_IS_REF(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XDG_APP_TYPE_REF))
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:440: trace: Macro: XDG_APP_IS_REF
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN GType xdg_app_ref_get_type (void);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: struct XdgAppRef {
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:710: trace: Struct(_): XdgAppRef
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   GObject parent;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0] };
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:861: trace: Store struct: XdgAppRef
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: typedef struct {
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:542: trace: typedef struct/union struct
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   GObjectClass parent_class;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:876: trace: struct/union level : 1
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0] } XdgAppRefClass;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:857: trace: Found object: XdgAppRef
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:861: trace: Store struct: XdgAppRefClass
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: G_DEFINE_AUTOPTR_CLEANUP_FUNC(XdgAppRef, g_object_unref)
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: typedef enum {
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:509: trace: typedef enum: -
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   XDG_APP_REF_KIND_APP,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0]   XDG_APP_REF_KIND_RUNTIME,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:726: trace: 1: [0] } XdgAppRefKind;
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN const char *  xdg_app_ref_get_name    (XdgAppRef      *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN const char *  xdg_app_ref_get_arch    (XdgAppRef      *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN const char *  xdg_app_ref_get_branch (XdgAppRef      *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN const char *  xdg_app_ref_get_commit  (XdgAppRef      *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN XdgAppRefKind xdg_app_ref_get_kind    (XdgAppRef      *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN char *        xdg_app_ref_format_ref  (XdgAppRef      *self);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: XDG_APP_EXTERN XdgAppRef *   xdg_app_ref_parse       (const char     *ref,
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0:                                                       GError        **error);
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: 
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:420: trace: 0: #endif /* __XDG_APP_REF_H__ */
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:896: trace: Scanning ../../lib/xdg-app-ref.h done
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:915: trace: Found gobject type 'XDG_APP_REF' from is_ macro
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:935: trace:   Hide instance docs for xdg_appref
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:939: trace:   Hide class docs for xdg_appref
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:943: trace:   Hide iface docs for xdg_appref
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:947: trace:   Hide iface docs for xdg_appref
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:963: trace: Decl '<TITLE>XdgAppRef</TITLE>,XdgAppRef,XdgAppRefClass,XdgAppRefKind'
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:964: trace: Std  'XDG_APP_IS_REF,XDG_APP_TYPE_REF,XDG_APP_REF'
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:218: trace: Scanning source directory: ../../lib
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:302: trace: File already scanned: ../../lib/xdg-app-remote-private.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:302: trace: File already scanned: ../../lib/xdg-app-error.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:302: trace: File already scanned: ../../lib/xdg-app.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:302: trace: File already scanned: ../../lib/xdg-app-remote-ref.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:302: trace: File already scanned: ../../lib/xdg-app-version-macros.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:302: trace: File already scanned: ../../lib/xdg-app-enum-types.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:302: trace: File already scanned: ../../lib/xdg-app-remote-ref-private.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:302: trace: File already scanned: ../../lib/xdg-app-installation.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:302: trace: File already scanned: ../../lib/xdg-app-remote.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:302: trace: File already scanned: ../../lib/xdg-app-installed-ref-private.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:302: trace: File already scanned: ../../lib/xdg-app-installed-ref.h
+/home/shared/gnome-jhbuild/bin/gtkdoc-scan:302: trace: File already scanned: ../../lib/xdg-app-ref.h

--- a/doc/reference/xdg-app-docs.xml
+++ b/doc/reference/xdg-app-docs.xml
@@ -14,6 +14,7 @@
 
   <chapter>
     <title>XDG-App</title>
+    <xi:include href="xml/xdg-app-error.xml"/>
     <xi:include href="xml/xdg-app-installation.xml"/>
     <xi:include href="xml/xdg-app-installed-ref.xml"/>
     <xi:include href="xml/xdg-app-remote-ref.xml"/>

--- a/lib/xdg-app-error.h
+++ b/lib/xdg-app-error.h
@@ -27,7 +27,9 @@
 G_BEGIN_DECLS
 
 /**
- * XdpErrorEnum:
+ * XdgAppError:
+ * @XDG_APP_ERROR_ALREADY_INSTALLED: App/runtime is already installed
+ * @XDG_APP_ERROR_NOT_INSTALLED: App/runtime is not installed
  */
 typedef enum {
   XDG_APP_ERROR_ALREADY_INSTALLED,

--- a/lib/xdg-app-installation.c
+++ b/lib/xdg-app-installation.c
@@ -681,7 +681,7 @@ progress_cb (OstreeAsyncProgress *progress, gpointer user_data)
  *
  * Install a new ref.
  *
- * Returns: (transfer full): The ref for the newly installed app or %null on failure
+ * Returns: (transfer full): The ref for the newly installed app or %NULL on failure
  */
 XdgAppInstalledRef *
 xdg_app_installation_install (XdgAppInstallation  *self,
@@ -805,7 +805,7 @@ xdg_app_installation_install (XdgAppInstallation  *self,
  *
  * Update a ref.
  *
- * Returns: (transfer full): The ref for the newly updated app (or the same if no update) or %null on failure
+ * Returns: (transfer full): The ref for the newly updated app (or the same if no update) or %NULL on failure
  */
 XdgAppInstalledRef *
 xdg_app_installation_update (XdgAppInstallation  *self,
@@ -923,7 +923,7 @@ xdg_app_installation_update (XdgAppInstallation  *self,
  *
  * Update a ref.
  *
- * Returns: %true on success
+ * Returns: %TRUE on success
  */
 XDG_APP_EXTERN gboolean
 xdg_app_installation_uninstall (XdgAppInstallation  *self,

--- a/lib/xdg-app-installation.c
+++ b/lib/xdg-app-installation.c
@@ -158,14 +158,18 @@ xdg_app_installation_get_is_user (XdgAppInstallation *self)
 /**
  * xdg_app_installation_launch:
  * @self: a #XdgAppInstallation
- * @name: ...
- * @arch: (nullable):...
- * @branch: (nullable): ...
- * @commit: (nullable): ...
+ * @name: name of the app to launch
+ * @arch: (nullable): which architecture to launch (default: current architecture)
+ * @branch: (nullable): which branch of the application (default: 'master')
+ * @commit: (nullable): the commit of @branch to launch
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
- * ...
+ * Launch an installed application.
+ *
+ * You can use xdg_app_installation_get_installed_ref() or
+ * xdg_app_installation_get_current_installed_app() to find out what builds
+ * are available, in order to get a value for @commit.
  *
  */
 gboolean
@@ -257,16 +261,17 @@ get_ref (XdgAppInstallation *self,
 /**
  * xdg_app_installation_get_installed_ref:
  * @self: a #XdgAppInstallation
- * @kind: ...
- * @name: ...
- * @arch: (nullable): ...
- * @branch: (nullable): ...
+ * @kind: whether this is an app or runtime
+ * @name: name of the app/runtime to fetch
+ * @arch: (nullable): which architecture to fetch (default: current architecture)
+ * @branch: (nullable): which branch to fetch (default: 'master')
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
- * ...
+ * Returns information about an installed app or runtime, such as the
+ * available builds, its size, location, etc.
  *
- * Returns: (transfer full): ...
+ * Returns: (transfer full): an #XdgAppInstalledRef
  */
 XdgAppInstalledRef *
 xdg_app_installation_get_installed_ref (XdgAppInstallation *self,
@@ -309,9 +314,11 @@ xdg_app_installation_get_installed_ref (XdgAppInstallation *self,
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
- * ...
+ * Get the last build of app @name that was installed with
+ * xdg_app_installation_install(), or %NULL if the app has never been installed
+ * locally.
  *
- * Returns: (transfer full): ...
+ * Returns: (transfer full): an #XdgAppInstalledRef
  */
 XdgAppInstalledRef *
 xdg_app_installation_get_current_installed_app (XdgAppInstallation *self,
@@ -662,7 +669,13 @@ progress_cb (OstreeAsyncProgress *progress, gpointer user_data)
 /**
  * xdg_app_installation_install:
  * @self: a #XdgAppInstallation
- * @progress: (scope call): the callback
+ * @remote_name: name of the remote to use
+ * @kind: what this ref contains (an #XdgAppRefKind)
+ * @name: name of the app/runtime to fetch
+ * @arch: (nullable): which architecture to fetch (default: current architecture)
+ * @branch: (nullable): which branch to fetch (default: 'master')
+ * @progress: (scope call): progress callback
+ * @progress_data: user data passed to @progress
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
@@ -780,7 +793,13 @@ xdg_app_installation_install (XdgAppInstallation  *self,
 /**
  * xdg_app_installation_update:
  * @self: a #XdgAppInstallation
+ * @flags: an #XdgAppUpdateFlags variable
+ * @kind: whether this is an app or runtime
+ * @name: name of the app or runtime to update
+ * @arch: (nullable): architecture of the app or runtime to update (default: current architecture)
+ * @branch: (nullable): name of the branch of the app or runtime to update (default: master)
  * @progress: (scope call): the callback
+ * @progress_data: user data passed to @progress
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
@@ -893,7 +912,12 @@ xdg_app_installation_update (XdgAppInstallation  *self,
 /**
  * xdg_app_installation_uninstall:
  * @self: a #XdgAppInstallation
+ * @kind: what this ref contains (an #XdgAppRefKind)
+ * @name: name of the app or runtime to uninstall
+ * @arch: architecture of the app or runtime to uninstall
+ * @branch: name of the branch of the app or runtime to uninstall
  * @progress: (scope call): the callback
+ * @progress_data: user data passed to @progress
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
@@ -1033,6 +1057,7 @@ xdg_app_installation_fetch_remote_metadata_sync (XdgAppInstallation *self,
 /**
  * xdg_app_installation_list_remote_refs_sync:
  * @self: a #XdgAppInstallation
+ * @remote_name: the name of the remote
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
@@ -1080,6 +1105,11 @@ xdg_app_installation_list_remote_refs_sync (XdgAppInstallation *self,
 /**
  * xdg_app_installation_fetch_remote_ref_sync:
  * @self: a #XdgAppInstallation
+ * @remote_name: the name of the remote
+ * @kind: what this ref contains (an #XdgAppRefKind)
+ * @name: name of the app/runtime to fetch
+ * @arch: (nullable): which architecture to fetch (default: current architecture)
+ * @branch: (nullable): which branch to fetch (default: 'master')
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *

--- a/lib/xdg-app-installation.h
+++ b/lib/xdg-app-installation.h
@@ -45,6 +45,14 @@ typedef struct {
   GObjectClass parent_class;
 } XdgAppInstallationClass;
 
+/**
+ * XdgAppUpdateFlags:
+ * @XDG_APP_UPDATE_FLAGS_NONE: Fetch remote builds and install the latest one (default)
+ * @XDG_APP_UPDATE_FLAGS_NO_DEPLOY: Don't install any new builds that might be fetched
+ * @XDG_APP_UPDATE_FLAGS_NO_PULL: Don't try to fetch new builds from the remote repo
+ *
+ * Flags to alter the behavior of xdg_app_installation_update().
+ */
 typedef enum {
   XDG_APP_UPDATE_FLAGS_NONE      = 0,
   XDG_APP_UPDATE_FLAGS_NO_DEPLOY = (1<<0),

--- a/lib/xdg-app-installation.h
+++ b/lib/xdg-app-installation.h
@@ -25,7 +25,7 @@
 #ifndef __XDG_APP_INSTALLATION_H__
 #define __XDG_APP_INSTALLATION_H__
 
-typedef struct XdgAppInstallation XdgAppInstallation;
+typedef struct _XdgAppInstallation XdgAppInstallation;
 
 #include <gio/gio.h>
 #include <xdg-app-installed-ref.h>
@@ -37,7 +37,7 @@ typedef struct XdgAppInstallation XdgAppInstallation;
 
 XDG_APP_EXTERN GType xdg_app_installation_get_type (void);
 
-struct XdgAppInstallation {
+struct _XdgAppInstallation {
   GObject parent;
 };
 

--- a/lib/xdg-app-installed-ref.h
+++ b/lib/xdg-app-installed-ref.h
@@ -25,7 +25,7 @@
 #ifndef __XDG_APP_INSTALLED_REF_H__
 #define __XDG_APP_INSTALLED_REF_H__
 
-typedef struct XdgAppInstalledRef XdgAppInstalledRef;
+typedef struct _XdgAppInstalledRef XdgAppInstalledRef;
 
 #include <gio/gio.h>
 #include <xdg-app-ref.h>
@@ -36,7 +36,7 @@ typedef struct XdgAppInstalledRef XdgAppInstalledRef;
 
 XDG_APP_EXTERN GType xdg_app_installed_ref_get_type (void);
 
-struct XdgAppInstalledRef {
+struct _XdgAppInstalledRef {
   XdgAppRef parent;
 };
 

--- a/lib/xdg-app-ref.h
+++ b/lib/xdg-app-ref.h
@@ -25,7 +25,7 @@
 #ifndef __XDG_APP_REF_H__
 #define __XDG_APP_REF_H__
 
-typedef struct XdgAppRef XdgAppRef;
+typedef struct _XdgAppRef XdgAppRef;
 
 #include <glib-object.h>
 
@@ -35,7 +35,7 @@ typedef struct XdgAppRef XdgAppRef;
 
 XDG_APP_EXTERN GType xdg_app_ref_get_type (void);
 
-struct XdgAppRef {
+struct _XdgAppRef {
   GObject parent;
 };
 

--- a/lib/xdg-app-ref.h
+++ b/lib/xdg-app-ref.h
@@ -48,6 +48,15 @@ typedef struct {
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(XdgAppRef, g_object_unref)
 #endif
 
+/**
+ * XdgAppRefKind:
+ * @XDG_APP_REF_KIND_APP: An application
+ * @XDG_APP_REF_KIND_RUNTIME: A runtime that applications can use.
+ *
+ * Currently xdg-app manages two types of binary artifacts: applications, and
+ * runtimes. Applications contain a program that desktop users can run, while
+ * runtimes contain only libraries and data.
+ */
 typedef enum {
   XDG_APP_REF_KIND_APP,
   XDG_APP_REF_KIND_RUNTIME,

--- a/lib/xdg-app-remote-ref.h
+++ b/lib/xdg-app-remote-ref.h
@@ -25,7 +25,7 @@
 #ifndef __XDG_APP_REMOTE_REF_H__
 #define __XDG_APP_REMOTE_REF_H__
 
-typedef struct XdgAppRemoteRef XdgAppRemoteRef;
+typedef struct _XdgAppRemoteRef XdgAppRemoteRef;
 
 #include <gio/gio.h>
 #include <xdg-app-ref.h>
@@ -36,7 +36,7 @@ typedef struct XdgAppRemoteRef XdgAppRemoteRef;
 
 XDG_APP_EXTERN GType xdg_app_remote_ref_get_type (void);
 
-struct XdgAppRemoteRef {
+struct _XdgAppRemoteRef {
   XdgAppRef parent;
 };
 

--- a/lib/xdg-app-remote.h
+++ b/lib/xdg-app-remote.h
@@ -25,7 +25,7 @@
 #ifndef __XDG_APP_REMOTE_H__
 #define __XDG_APP_REMOTE_H__
 
-typedef struct XdgAppRemote XdgAppRemote;
+typedef struct _XdgAppRemote XdgAppRemote;
 
 #include <gio/gio.h>
 #include <xdg-app-remote-ref.h>
@@ -36,7 +36,7 @@ typedef struct XdgAppRemote XdgAppRemote;
 
 XDG_APP_EXTERN GType xdg_app_remote_get_type (void);
 
-struct XdgAppRemote {
+struct _XdgAppRemote {
   GObject parent;
 };
 


### PR DESCRIPTION
I may have misunderstood some of the functions.. but hopefully this is useful!

This fixes all of the warnings in gtk-doc generation except for these ones

```
:0: warning: Field descriptions for struct XdgAppInstallationClass are missing in source code comment block.
:0: warning: Field descriptions for struct XdgAppInstalledRefClass are missing in source code comment block.
:0: warning: Field descriptions for struct XdgAppRemoteRefClass are missing in source code comment block.
:0: warning: Field descriptions for struct XdgAppRefClass are missing in source code comment block.
:0: warning: Field descriptions for struct XdgAppRemoteClass are missing in source code comment block.
```

Seems a bit pointless to document the classes since they have no interesting members, perhaps they should be ignored instead of that's possible.