### PR TITLE
builder: Skip checking out disabled submodules

### DIFF
--- a/builder/builder-source-git.c
+++ b/builder/builder-source-git.c
@@ -415,12 +415,25 @@ git_extract_submodule (const char *repo_url,
           g_autoptr(GFile) child_dir = NULL;
           g_autofree char *child_url = NULL;
           g_autofree char *option = NULL;
+          g_autofree char *update_method = NULL;
           g_autofree char *child_relative_url = NULL;
           g_autofree char *mirror_dir_as_url = NULL;
           g_auto(GStrv) words = NULL;
           if (*lines[i] == 0)
             continue;
           words = g_strsplit (lines[i] + 1, " ", 3);
+
+          // Skip any submodules that are disabled (have the update method set to "none")
+          // Only check if the command succeeds. If it fails, the update method is not set.
+          option = g_strdup_printf("submodule.%s.update", words[1]);
+          if (git(checkout_dir, &update_method, NULL,
+                  "config", "-f", ".gitmodules", option, NULL)) {
+            /* Trim trailing whitespace */
+            g_strchomp(update_method);
+
+            if (g_strcmp0(update_method, "none") == 0)
+              continue;
+          }
 
           option = g_strdup_printf ("submodule.%s.url", words[1]);
           if (!git (checkout_dir, &child_relative_url, error,


### PR DESCRIPTION
When a submodule is disabled, xdg-app would still try to check it out. Because it wasn't actually checked out, when xdg-app would step into the submodule and try to check out sub-submodules, it would end up seeing submodules in the parent module (because there was no .git directory in the empty submodule) and fail.