### PR TITLE
Build top-level directory before building documentation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,7 @@ DISTCLEANFILES= $(NULL)
 BUILT_SOURCES = $(NULL)
 
 if BUILD_DOCUMENTATION
-SUBDIRS = doc
+SUBDIRS = . doc
 endif
 
 %.service: %.service.in config.log


### PR DESCRIPTION
Otherwise, we try to scan a library that we haven't yet built.

---

To reproduce:

```
$ ./configure --enable-gtk-doc
...
$ make
  GEN      lib/xdg-app-enum-types.c
  GEN      lib/xdg-app-enum-types.h
make  all-recursive
make[1]: Entering directory '/home/smcv/src/xdg-app'
Making all in doc
make[2]: Entering directory '/home/smcv/src/xdg-app/doc'
Making all in reference
make[3]: Entering directory '/home/smcv/src/xdg-app/doc/reference'
  DOC   Preparing build
  DOC   Scanning header files
  DOC   Introspecting gobjects
libtool: link: cannot find the library `../../libxdg-app.la' or unhandled argument `../../libxdg-app.la'
Linking of scanner failed: 
Makefile:1002: recipe for target 'scan-build.stamp' failed
```
```
