### PR TITLE
Hide non-public symbols from libglnx and libxdgapp-common

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,7 +43,11 @@ EXTRA_DIST =
 lib_LTLIBRARIES =
 noinst_LTLIBRARIES = libglnx.la
 libglnx_srcpath := $(srcdir)/libglnx
-libglnx_cflags := $(BASE_CFLAGS) "-I$(libglnx_srcpath)"
+libglnx_cflags := \
+	$(BASE_CFLAGS) \
+	"-I$(libglnx_srcpath)" \
+	$(HIDDEN_VISIBILITY_CFLAGS) \
+	$(NULL)
 libglnx_libs := $(BASE_LIBS)
 include libglnx/Makefile-libglnx.am.inc
 

--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -43,7 +43,15 @@ libxdgapp_common_la_SOURCES = \
 	$(systemd_dbus_built_sources)	\
 	$(NULL)
 
-libxdgapp_common_la_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(XAUTH_CFLAGS) -I$(srcdir)/dbus-proxy
+libxdgapp_common_la_CFLAGS = \
+	$(AM_CFLAGS) \
+	$(BASE_CFLAGS) \
+	$(HIDDEN_VISIBILITY_CFLAGS) \
+	$(OSTREE_CFLAGS) \
+	$(SOUP_CFLAGS) \
+	$(XAUTH_CFLAGS) \
+	-I$(srcdir)/dbus-proxy \
+	$(NULL)
 libxdgapp_common_la_LIBADD = libglnx.la $(BASE_LIBS) $(OSTREE_LIBS) $(SOUP_LIBS) $(XAUTH_LIBS)
 
 bin_PROGRAMS += \

--- a/common/xdg-app-portal-error.h
+++ b/common/xdg-app-portal-error.h
@@ -42,7 +42,7 @@ typedef enum {
 
 #define XDG_APP_PORTAL_ERROR xdg_app_error_quark()
 
-GQuark  xdg_app_error_quark      (void);
+XDG_APP_EXTERN GQuark  xdg_app_error_quark      (void);
 
 G_END_DECLS
 


### PR DESCRIPTION
This avoids exporting glnx_*, calc_sizes(), etc. However, we do want to
export xdg_app_error_quark(), so do that.