### PR TITLE
Fix `make check` when FUSE is unavailable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,11 @@ lib/xdg-app-enum-types.c
 lib/xdg-app-enum-types.h
 test-libxdg-app
 XdgApp-1.0.*
+/doc/reference/gtkdoc-check.log
+/doc/reference/gtkdoc-check.test
+/doc/reference/gtkdoc-check.trs
+/test-doc-portal
+/test-doc-portal.log
+/test-doc-portal.trs
+/testdb.log
+/testdb.trs

--- a/tests/test-doc-portal.c
+++ b/tests/test-doc-portal.c
@@ -211,10 +211,9 @@ test_recursive_doc (void)
   g_assert_cmpstr (id, ==, id3);
 }
 
-int
-main (int argc, char **argv)
+static void
+global_setup (void)
 {
-  int res;
   gboolean inited;
   GError *error = NULL;
   gint exit_status;
@@ -251,13 +250,12 @@ main (int argc, char **argv)
   g_assert_no_error (error);
   g_assert (inited);
   g_assert (mountpoint != NULL);
+}
 
-  g_test_init (&argc, &argv, NULL);
-
-  g_test_add_func ("/db/create_doc", test_create_doc);
-  g_test_add_func ("/db/recursive_doc", test_recursive_doc);
-
-  res = g_test_run ();
+static void
+global_teardown (void)
+{
+  GError *error = NULL;
 
   g_free (mountpoint);
 
@@ -277,6 +275,23 @@ main (int argc, char **argv)
   sleep (1);
 
   glnx_shutil_rm_rf_at (-1, outdir, NULL, NULL);
+}
+
+int
+main (int argc, char **argv)
+{
+  int res;
+
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/db/create_doc", test_create_doc);
+  g_test_add_func ("/db/recursive_doc", test_recursive_doc);
+
+  global_setup ();
+
+  res = g_test_run ();
+
+  global_teardown ();
 
   return res;
 }


### PR DESCRIPTION
FUSE could be unavailable because `/dev/fuse` doesn't exist or is only available to members of a specific group, or because the setuid helper `fusermount` isn't executable (perhaps executable by members of a specific group, as it was in Debian in the past). The current Ubuntu PPA packaging disables the test that uses FUSE altogether, but it would be better to mark all of its test-cases as skipped. This branch does so.

The tests still fail for me, because gtkdoc-check reports many undocumented symbols. Perhaps it would be good to disable gtkdoc-check until the documentation is believed to be more complete, so that any test failures in the actual functional bits are more visible - I'd like to be able to make test failure cause a build failure in Debian.