### PR TITLE
Move XDG_APP_SYSTEMDIR to /var/lib/xdg-app or similar

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ service_DATA = $(NULL)
 
 AM_CPPFLAGS =						\
 	-DXDG_APP_BINDIR=\"$(bindir)\"			\
-	-DXDG_APP_SYSTEMDIR=\"$(localstatedir)/xdg-app\"\
+	-DXDG_APP_SYSTEMDIR=\"$(localstatedir)/lib/xdg-app\"\
 	-DXDG_APP_BASEDIR=\"$(pkgdatadir)\"		\
 	-DXDG_APP_TRIGGERDIR=\"$(pkgdatadir)/triggers\" \
 	-DSYSTEM_FONTS_DIR=\"$(SYSTEM_FONTS_DIR)\"	\


### PR DESCRIPTION
The FHS specifies a limited number of subdirectories for /var,
which do not include xdg-app. Packaging systems like RPM and dpkg
use a subdirectory of /var/lib, so it seems appropriate for system-wide
xdg-app runtimes and apps too.
