### PR TITLE
Consistently call g_assert_no_error before other assertions

### DIFF
--- a/tests/test-doc-portal.c
+++ b/tests/test-doc-portal.c
@@ -98,8 +98,8 @@ export_file (const char *path, gboolean unique)
                                                          NULL,
                                                          &error);
   g_object_unref (fd_list);
-  g_assert (reply != NULL);
   g_assert_no_error (error);
+  g_assert (reply != NULL);
 
   g_variant_get (reply, "(s)", &doc_id);
   g_assert (doc_id != NULL);
@@ -233,8 +233,8 @@ main (int argc, char **argv)
   g_setenv ("XDG_RUNTIME_DIR", outdir, TRUE);
 
   g_spawn_command_line_sync (DOC_PORTAL " -d", NULL, NULL, &exit_status, &error);
-  g_assert_cmpint (exit_status, ==, 0);
   g_assert_no_error (error);
+  g_assert_cmpint (exit_status, ==, 0);
 
   session_bus = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, &error);
   g_assert_no_error (error);


### PR DESCRIPTION
If a call fails, an assertion message that contains the error domain,
code and message is a lot more useful than reporting that an
assertion like "reply != NULL" failed.