### PR TITLE
Make `make distcheck` work

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,7 @@ libexec_PROGRAMS = $(NULL)
 CLEANFILES = $(NULL)
 DISTCLEANFILES= $(NULL)
 BUILT_SOURCES = $(NULL)
+EXTRA_DIST =
 
 if BUILD_DOCUMENTATION
 SUBDIRS = . doc
@@ -20,6 +21,7 @@ dbus_service_DATA = $(NULL)
 systemduserunit_DATA = $(NULL)
 CLEANFILES += $(dbus_service_DATA)
 CLEANFILES += $(systemduserunit_DATA)
+EXTRA_DIST += $(service_in_files)
 
 AM_CPPFLAGS =						\
 	-DXDG_APP_BINDIR=\"$(bindir)\"			\
@@ -40,8 +42,6 @@ dist_triggers_SCRIPTS = \
 	triggers/mime-database.trigger \
 	triggers/desktop-database.trigger \
 	$(NULL)
-
-EXTRA_DIST =
 
 lib_LTLIBRARIES =
 noinst_LTLIBRARIES = libglnx.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -72,7 +72,6 @@ EXTRA_DIST += $(completion_DATA)
 profiledir = $(sysconfdir)/profile.d
 profile_DATA = xdg-app.sh
 EXTRA_DIST += \
-	$(dbus_service_in_files) \
 	profile/xdg-app.sh.in \
 	$(NULL)
 DISTCLEANFILES += xdg-app.sh

--- a/configure.ac
+++ b/configure.ac
@@ -226,10 +226,18 @@ GOBJECT_INTROSPECTION_CHECK([1.40.0])
 # gtkdocize greps for ^GTK_DOC_CHECK, so we need to put it on its own line
 m4_ifdef([GTK_DOC_CHECK], [
 GTK_DOC_CHECK([1.20], [--flavour no-tmpl])
+
+AC_ARG_ENABLE([gtk-doc-check],
+              [AS_HELP_STRING([--enable-gtk-doc-check],
+                              [Check completeness of documentation in 'make check'])],
+    [],
+    [enable_gtk_doc_check=no])
 ],[
 enable_gtk_doc="disabled (no gtk-doc)"
+enable_gtk_doc_check="disabled (no gtk-doc)"
 AM_CONDITIONAL([ENABLE_GTK_DOC], [false])
 ])
+AM_CONDITIONAL([ENABLE_GTK_DOC_CHECK], [test "x$enable_gtk_doc_check" = xyes])
 
 ##################################################
 # Visibility handling

--- a/doc/reference/Makefile.am
+++ b/doc/reference/Makefile.am
@@ -28,7 +28,7 @@ GTKDOC_LIBS = $(top_builddir)/libxdg-app.la $(BASE_LIBS)
 
 include $(top_srcdir)/gtk-doc.make
 
-if ENABLE_GTK_DOC
+if ENABLE_GTK_DOC_CHECK
 TESTS_ENVIRONMENT = \
 	DOC_MODULE=$(DOC_MODULE) DOC_MAIN_SGML_FILE=$(DOC_MAIN_SGML_FILE) \
 	SRCDIR=$(abs_srcdir) BUILDDIR=$(abs_builddir)

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -22,11 +22,11 @@ tests/services/org.freedesktop.portal.Documents.service: document-portal/org.fre
 	mkdir -p tests/services
 	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(abs_top_builddir)|" $< > $@
 
-tests/services/xdg-app-session.service: session-helper/xdg-app-session.service.in
+tests/services/org.freedesktop.XdgApp.service: session-helper/org.freedesktop.XdgApp.service.in
 	mkdir -p tests/services
 	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(abs_top_builddir)|" $< > $@
 
-test_doc_portal_DEPENDENCIES = tests/services/org.freedesktop.portal.Documents.service  tests/services/xdg-app-session.service
+test_doc_portal_DEPENDENCIES = tests/services/org.freedesktop.portal.Documents.service  tests/services/org.freedesktop.XdgApp.service
 
 check_PROGRAMS = $(TEST_PROGS)
 
@@ -35,4 +35,7 @@ TESTS=testdb test-doc-portal
 @VALGRIND_CHECK_RULES@
 VALGRIND_SUPPRESSIONS_FILES=tests/xdg-app.supp
 EXTRA_DIST += tests/xdg-app.supp tests/dbs/no_tables
-DISTCLEANFILES += tests/services/xdg-app-session.service tests/services/org.freedesktop.portal.Documents.service
+CLEANFILES += \
+	tests/services/org.freedesktop.XdgApp.service \
+	tests/services/org.freedesktop.portal.Documents.service \
+	$(NULL)


### PR DESCRIPTION
It previously wasn't possible to `make distcheck` because `gtkdoc-check` would fail. We know the documentation is incomplete, so I suggest turning off `gtkdoc-check` by default, so that failures in the actual tests are made more visible.

I also broke distribution of `.service` files in PR #107 (sorry about that), which this branch fixes.