### PR TITLE
Document --force-clean

### DIFF
--- a/doc/xdg-app-builder.xml
+++ b/doc/xdg-app-builder.xml
@@ -668,6 +668,15 @@
                 </para></listitem>
             </varlistentry>
 
+            <varlistentry>
+                <term><option>--force-clean</option></term>
+
+                <listitem><para>
+                    Erase the previous contents of DIRECTORY if it is
+                    not empty.
+                </para></listitem>
+            </varlistentry>
+
           </variablelist>
     </refsect1>
 


### PR DESCRIPTION
We shouldn't allow new options to be added without documentation.