### PR TITLE
session-helper: connect the D-Bus and systemd services

### DIFF
--- a/session-helper/org.freedesktop.XdgApp.service.in
+++ b/session-helper/org.freedesktop.XdgApp.service.in
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.freedesktop.XdgApp
 Exec=@libexecdir@/xdg-app-session-helper
+SystemdService=xdg-app-session-helper.service


### PR DESCRIPTION
The session-helper already has both D-Bus session and systemd user services, they just aren't linked together properly.

(The other D-Bus session service, the document portal, is already correct.)