### PR TITLE
Skip locale exportation when there is no separate locales dir

### DIFF
--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -34,6 +34,8 @@
 #include "libgsystem.h"
 #include "libglnx/libglnx.h"
 
+#define LOCALES_SEPARATE_DIR "share/runtime/locale"
+
 struct BuilderManifest {
   GObject parent;
 
@@ -1625,12 +1627,12 @@ builder_manifest_finish (BuilderManifest *self,
       if (self->build_runtime)
         {
           debuginfo_dir = g_file_resolve_relative_path (app_dir, "usr/lib/debug");
-          locale_parent_dir = g_file_resolve_relative_path (app_dir, "usr/share/runtime/locale");
+          locale_parent_dir = g_file_resolve_relative_path (app_dir, "usr/" LOCALES_SEPARATE_DIR);
         }
       else
         {
           debuginfo_dir = g_file_resolve_relative_path (app_dir, "files/lib/debug");
-          locale_parent_dir = g_file_resolve_relative_path (app_dir, "files/share/runtime/locale");
+          locale_parent_dir = g_file_resolve_relative_path (app_dir, "files/" LOCALES_SEPARATE_DIR);
         }
 
       if (self->separate_locales && g_file_query_exists (locale_parent_dir, NULL))
@@ -1645,9 +1647,10 @@ builder_manifest_finish (BuilderManifest *self,
 
           extension_contents = g_strdup_printf("\n"
                                                "[Extension %s.Locale]\n"
-                                               "directory=share/runtime/locale\n"
+                                               "directory=%s\n"
                                                "subdirectories=true\n",
-                                               self->id);
+                                               self->id,
+                                               LOCALES_SEPARATE_DIR);
 
           output = g_file_append_to (metadata_file, G_FILE_CREATE_NONE, NULL, error);
           if (output == NULL)
@@ -1781,7 +1784,7 @@ builder_manifest_create_platform (BuilderManifest *self,
           if (!builder_migrate_locale_dirs (root_dir, error))
             return FALSE;
 
-          locale_dir = g_file_resolve_relative_path (root_dir, "share/runtime/locale");
+          locale_dir = g_file_resolve_relative_path (root_dir, LOCALES_SEPARATE_DIR);
         }
 
       if (self->metadata_platform)
@@ -1899,9 +1902,10 @@ builder_manifest_create_platform (BuilderManifest *self,
 
           extension_contents = g_strdup_printf("\n"
                                                "[Extension %s.Locale]\n"
-                                               "directory=share/runtime/locale\n"
+                                               "directory=%s\n"
                                                "subdirectories=true\n",
-                                               self->id_platform);
+                                               self->id_platform,
+                                               LOCALES_SEPARATE_DIR);
 
           output = g_file_append_to (metadata_file, G_FILE_CREATE_NONE, NULL, error);
           if (output == NULL)

--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -1633,7 +1633,7 @@ builder_manifest_finish (BuilderManifest *self,
           locale_parent_dir = g_file_resolve_relative_path (app_dir, "files/share/runtime/locale");
         }
 
-      if (self->separate_locales)
+      if (self->separate_locales && g_file_query_exists (locale_parent_dir, NULL))
         {
           g_autoptr(GFile) metadata_file = NULL;
           g_autofree char *extension_contents = NULL;
@@ -1720,6 +1720,7 @@ builder_manifest_create_platform (BuilderManifest *self,
                                   GError          **error)
 {
   GFile *app_dir = builder_context_get_app_dir (context);
+  g_autoptr(GFile) locale_dir = NULL;
   int i;
 
   if (!self->build_runtime ||
@@ -1779,6 +1780,8 @@ builder_manifest_create_platform (BuilderManifest *self,
 
           if (!builder_migrate_locale_dirs (root_dir, error))
             return FALSE;
+
+          locale_dir = g_file_resolve_relative_path (root_dir, "share/runtime/locale");
         }
 
       if (self->metadata_platform)
@@ -1883,7 +1886,7 @@ builder_manifest_create_platform (BuilderManifest *self,
             }
         }
 
-      if (self->separate_locales)
+      if (self->separate_locales && locale_dir && g_file_query_exists (locale_dir, NULL))
         {
           g_autoptr(GFile) metadata_file = NULL;
           g_autofree char *extension_contents = NULL;


### PR DESCRIPTION
This will avoid errors when separate_locales is set to true but the locales directory does not exist. This is the case of many apps that do not support separate locales but haven't specifically set separate_locales to false in the configuration.

Please note that the second commit is just because I get a bit nervous when seeing so many repeated path strings as it can lead to human-errors when changing the code in the future (but I am fine if you prefer to not apply it) :smile_cat: 
Ideally we'd have a private header with these paths to be shared across the modules that need them.