### PR TITLE
Expands docs around dbus policy options

### DIFF
--- a/doc/xdg-app-build-finish.xml
+++ b/doc/xdg-app-build-finish.xml
@@ -182,8 +182,9 @@
 
                 <listitem><para>
                     Allow the application to own the well known name NAME on the session bus.
+                    If NAME ends with .*, it allows the application to own all matching names.
+
                     This updates the [Session Bus Policy] group in the metadata.
-                    This overrides to the Context section from the application metadata.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -193,6 +194,7 @@
 
                 <listitem><para>
                     Allow the application to talk to the well known name NAME on the session bus.
+                    If NAME ends with .*, it allows the application to talk to all matching names.
                     This updates the [Session Bus Policy] group in the metadata.
                     This option can be used multiple times.
                 </para></listitem>
@@ -203,8 +205,8 @@
 
                 <listitem><para>
                     Allow the application to own the well known name NAME on the system bus.
+                    If NAME ends with .*, it allows the application to own all matching names.
                     This updates the [System Bus Policy] group in the metadata.
-                    This overrides to the Context section from the application metadata.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -214,6 +216,7 @@
 
                 <listitem><para>
                     Allow the application to talk to the well known name NAME on the system bus.
+                    If NAME ends with .*, it allows the application to talk to all matching names.
                     This updates the [System Bus Policy] group in the metadata.
                     This option can be used multiple times.
                 </para></listitem>

--- a/doc/xdg-app-run.xml
+++ b/doc/xdg-app-run.xml
@@ -240,6 +240,7 @@
 
                 <listitem><para>
                     Allow the application to own the well known name NAME on the session bus.
+                    If NAME ends with .*, it allows the application to own all matching names.
                     This overrides to the Context section from the application metadata.
                     This option can be used multiple times.
                 </para></listitem>
@@ -250,6 +251,29 @@
 
                 <listitem><para>
                     Allow the application to talk to the well known name NAME on the session bus.
+                    If NAME ends with .*, it allows the application to talk to all matching names.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--system-own-name=NAME</option></term>
+
+                <listitem><para>
+                    Allow the application to own the well known name NAME on the system bus.
+                    If NAME ends with .*, it allows the application to own all matching names.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--system-talk-name=NAME</option></term>
+
+                <listitem><para>
+                    Allow the application to talk to the well known name NAME on the system bus.
+                    If NAME ends with .*, it allows the application to talk to all matching names.
                     This overrides to the Context section from the application metadata.
                     This option can be used multiple times.
                 </para></listitem>


### PR DESCRIPTION
We should mention that the NAME may end with .* to match multiple
names. Also, add the --system- variants of these options to the
xdg-app run man page where they were missing.