### PR TITLE
Use i386 for the architecture when compiled in that arch

### DIFF
--- a/common/xdg-app-utils.c
+++ b/common/xdg-app-utils.c
@@ -178,6 +178,14 @@ xdg_app_get_arch (void)
   if (arch != NULL)
     return arch;
 
+  /* Avoid using uname is the user's architecture is 32 bit as it
+   * can get the wrong value. E.g.: when the kernel has a
+   * different architecture than the user space */
+#if defined(__i386__)
+  arch = "i386";
+  return arch;
+#endif
+
   if (uname (&buf))
     {
       arch = "unknown";


### PR DESCRIPTION
This fixes the issue of using 64 bit when a system has a 64 bit kernel
but a 32 bit user space on it.

Alex, it is probably worth removing the version comparison below that canonicalizes the *i386* version. let me know if you want that gone.

*Slightly related topic:* As I said on IRC, Richard would like this function to be exposed so he can use it in appstream-glib instead of having it copied there as it's currently the case.