### PR TITLE
autogen.sh: Look for bubblewrap submodule too

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -18,7 +18,7 @@ fi
 # regenerated from their corresponding *.in files by ./configure anyway.
 touch INSTALL
 
-if ! test -f libglnx/README.md; then
+if ! test -f libglnx/README.md -a -f bubblewrap/README.md; then
     git submodule update --init
 fi
 # Workaround automake bug with subdir-objects and computed paths


### PR DESCRIPTION
autogen.sh had code to init submodules if the libglnx directory
is empty. We should also check for bubblewrap now.