### PR TITLE
Improve installed-tests and build-time tests

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -57,15 +57,15 @@ tests/test-basic.sh: tests/package_version.txt
 installed_test_SCRIPTS += \
 	buildutil/tap-driver.sh \
 	tests/test-configure \
-	tests/package_version.txt \
 	tests/make-test-app.sh \
 	tests/make-test-runtime.sh \
 	tests/make-test-bundles.sh \
-	tests/libtest.sh \
 	$(NULL)
 
 installed_test_data = \
+	tests/libtest.sh \
 	tests/org.test.Hello.png \
+	tests/package_version.txt \
 	tests/test.json \
 	tests/session.conf.in \
 	$(NULL)

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -16,7 +16,7 @@ testdb_LDADD = \
              $(NULL)
 testdb_SOURCES = tests/testdb.c
 
-test_doc_portal_CFLAGS = $(BASE_CFLAGS) -DTEST_SERVICES=\""$(abs_top_builddir)/tests/services"\" -DDOC_PORTAL=\""$(abs_top_builddir)/xdg-document-portal"\"
+test_doc_portal_CFLAGS = $(BASE_CFLAGS)
 test_doc_portal_LDADD = \
              $(BASE_LIBS) \
              $(OSTREE_LIBS) \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -7,7 +7,7 @@ TESTS_ENVIRONMENT += OT_TESTS_DEBUG=1 \
 	PATH=$$(cd $(top_builddir) && pwd):$${PATH} \
 	$(NULL)
 
-testdb_CFLAGS = $(BASE_CFLAGS) -DDB_DIR=\"$(abs_srcdir)/tests/dbs\"
+testdb_CFLAGS = $(BASE_CFLAGS)
 testdb_LDADD = \
              $(BASE_LIBS) \
              $(OSTREE_LIBS) \
@@ -69,6 +69,11 @@ installed_test_data = \
 	tests/test.json \
 	tests/session.conf.in \
 	$(NULL)
+
+installed_test_dbsdir = $(installed_testdir)/dbs
+if ENABLE_INSTALLED_TESTS
+installed_test_dbs_DATA = tests/dbs/no_tables
+endif
 
 EXTRA_DIST += $(installed_test_SCRIPTS) $(installed_test_data)
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -172,6 +172,17 @@ run_sh () {
     ${CMD_PREFIX} flatpak run --command=bash ${ARGS-} org.test.Hello -c "$*"
 }
 
+skip_without_bwrap () {
+    if [ -z "${FLATPAK_BWRAP:-}" ]; then
+        # running installed-tests: assume we know what we're doing
+        :
+    elif ! "$FLATPAK_BWRAP" --ro-bind / / /bin/true > bwrap-result 2>&1; then
+        sed -e 's/^/# /' < bwrap-result
+        echo "1..0 # SKIP Cannot run bwrap"
+        exit 0
+    fi
+}
+
 sed s#@testdir@#${test_builddir}# ${test_srcdir}/session.conf.in > session.conf
 eval `dbus-launch --config-file=session.conf --sh-syntax`
 

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -25,7 +25,7 @@ echo "1..3"
 
 ${FLATPAK} --version > version_out
 
-VERSION=`cat $(dirname $0)/package_version.txt`
+VERSION=`cat "$test_builddir/package_version.txt"`
 assert_file_has_content version_out "^flatpak $VERSION$"
 
 echo "ok version"

--- a/tests/test-builder.sh
+++ b/tests/test-builder.sh
@@ -21,6 +21,8 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
+skip_without_bwrap
+
 echo "1..3"
 
 setup_repo

--- a/tests/test-configure
+++ b/tests/test-configure
@@ -7,14 +7,14 @@ fi
 cat <<EOF > Makefile
 all:
 	echo Building
-	if [ x\$(CFLAGS) != "x-O2 -g" ]; then exit 1; fi
-	if [ x\$(FOO) != xbar ]; then exit 1; fi
-	if [ x\$(BAR) != x2 ]; then exit 1; fi
+	if [ "x\$(CFLAGS)" != "x-O2 -g" ]; then exit 1; fi
+	if [ "x\$(FOO)" != xbar ]; then exit 1; fi
+	if [ "x\$(BAR)" != x2 ]; then exit 1; fi
 
 install:
 	echo Installing
-	if [ x\$(FOO) != xbar ]; then exit 1; fi
-	if [ x\$(BAR) != x3 ]; then exit 1; fi
+	if [ "x\$(FOO)" != xbar ]; then exit 1; fi
+	if [ "x\$(BAR)" != x3 ]; then exit 1; fi
 	mkdir -p /app/bin
 	cp -a hello2.sh /app/bin/
 	mkdir -p /app/share

--- a/tests/test-doc-portal.c
+++ b/tests/test-doc-portal.c
@@ -334,7 +334,6 @@ global_setup (void)
   gboolean inited;
   g_autofree gchar *fusermount = NULL;
   GError *error = NULL;
-  gint exit_status;
   g_autofree gchar *services = NULL;
 
   fusermount = g_find_program_in_path ("fusermount");
@@ -359,10 +358,6 @@ global_setup (void)
 
   /* g_test_dbus_up unsets this, so re-set */
   g_setenv ("XDG_RUNTIME_DIR", outdir, TRUE);
-
-  g_spawn_command_line_sync (DOC_PORTAL " -d", NULL, NULL, &exit_status, &error);
-  g_assert_no_error (error);
-  g_assert_cmpint (exit_status, ==, 0);
 
   session_bus = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, &error);
   g_assert_no_error (error);

--- a/tests/test-doc-portal.c
+++ b/tests/test-doc-portal.c
@@ -335,6 +335,7 @@ global_setup (void)
   g_autofree gchar *fusermount = NULL;
   GError *error = NULL;
   gint exit_status;
+  g_autofree gchar *services = NULL;
 
   fusermount = g_find_program_in_path ("fusermount");
   /* cache result so subsequent tests can be marked as skipped */
@@ -352,7 +353,8 @@ global_setup (void)
   g_setenv ("XDG_DATA_HOME", outdir, TRUE);
 
   dbus = g_test_dbus_new (G_TEST_DBUS_NONE);
-  g_test_dbus_add_service_dir (dbus, TEST_SERVICES);
+  services = g_test_build_filename (G_TEST_BUILT, "services", NULL);
+  g_test_dbus_add_service_dir (dbus, services);
   g_test_dbus_up (dbus);
 
   /* g_test_dbus_up unsets this, so re-set */

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -80,23 +80,23 @@ ARGS="--share=ipc" run_sh readlink /proc/self/ns/ipc > shared_ipc_ns
 assert_not_streq `cat unshared_ipc_ns` `readlink /proc/self/ns/ipc`
 assert_streq `cat shared_ipc_ns` `readlink /proc/self/ns/ipc`
 
-if run_sh cat $(dirname $0)/package_version.txt &> /dev/null; then
+if run_sh cat "${test_builddir}/package_version.txt" &> /dev/null; then
     assert_not_reached "Unexpectedly allowed to access file"
 fi
 
-ARGS="--filesystem=$(dirname $0)" run_sh cat $(dirname $0)/package_version.txt > /dev/null
-ARGS="--filesystem=host" run_sh cat $(dirname $0)/package_version.txt > /dev/null
+ARGS="--filesystem=${test_builddir}" run_sh cat "${test_builddir}/package_version.txt" > /dev/null
+ARGS="--filesystem=host" run_sh cat "${test_builddir}/package_version.txt" > /dev/null
 
 echo "ok namespaces"
 
 $FLATPAK override --user --filesystem=host org.test.Hello
-run_sh cat $(dirname $0)/package_version.txt &> /dev/null
-if ARGS="--nofilesystem=host" run_sh cat $(dirname $0)/package_version.txt &> /dev/null; then
+run_sh cat "${test_builddir}/package_version.txt" &> /dev/null
+if ARGS="--nofilesystem=host" run_sh cat "${test_builddir}/package_version.txt" &> /dev/null; then
     assert_not_reached "Unexpectedly allowed to access --nofilesystem=host file"
 fi
 $FLATPAK override --user --nofilesystem=host org.test.Hello
 
-if run_sh cat $(dirname $0)/package_version.txt &> /dev/null; then
+if run_sh cat "${test_builddir}/package_version.txt" &> /dev/null; then
     assert_not_reached "Unexpectedly allowed to access file"
 fi
 

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -21,6 +21,8 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
+skip_without_bwrap
+
 echo "1..5"
 
 setup_repo

--- a/tests/test.json
+++ b/tests/test.json
@@ -29,7 +29,7 @@
                     "type": "file",
                     "path": "test-configure",
                     "dest-filename": "configure",
-                    "sha256": "ce0a7014057cc45ac6cfa4b84fe848d46b1225f4ce03f1b52d5ab73521816cbf"
+                    "sha256": "675a1ac2feec4d4f54e581b4b01bc3cfd2c1cf31aa5963574d31228c8a11b7e7"
                 },
                 {
                     "type": "file",

--- a/tests/testdb.c
+++ b/tests/testdb.c
@@ -156,18 +156,18 @@ test_db_open (void)
   GError *error = NULL;
   FlatpakDb *db;
 
-  db = flatpak_db_new (DB_DIR "/does_not_exist", TRUE, &error);
+  db = flatpak_db_new (g_test_get_filename (G_TEST_DIST, "dbs", "does_not_exist", NULL), TRUE, &error);
   g_assert_error (error, G_FILE_ERROR, G_FILE_ERROR_NOENT);
   g_assert (db == NULL);
   g_clear_error (&error);
 
-  db = flatpak_db_new (DB_DIR "/does_not_exist", FALSE, &error);
+  db = flatpak_db_new (g_test_get_filename (G_TEST_DIST, "dbs", "does_not_exist", NULL), FALSE, &error);
   g_assert_no_error (error);
   g_assert (db != NULL);
   g_clear_error (&error);
   g_object_unref (db);
 
-  db = flatpak_db_new (DB_DIR "/no_tables", TRUE, &error);
+  db = flatpak_db_new (g_test_get_filename (G_TEST_DIST, "dbs", "no_tables", NULL), TRUE, &error);
   g_assert_error (error, G_FILE_ERROR, G_FILE_ERROR_INVAL);
   g_assert (db == NULL);
   g_clear_error (&error);


### PR DESCRIPTION
I've been updating the Debian packaging of xdg-app for the rename to Flatpak and the move to installed-tests. Several test-related issues are fixed in this branch:

* Some non-executables were installed executable.
* Even when installed, testdb and test-doc-portal weren't actually testing the installed binaries, but instead were testing what was in the `builddir`.
* Build-time tests failed in a `srcdir != builddir` build, because `package_version.txt` was looked for in the `srcdir`.
* In an autobuilder environment, `bwrap` won't necessarily work: it won't be setuid or setcap yet, we are't root, and we don't necessarily have the necessary kernel configuration or runtime sysctl parameters to allow unprivileged user namespaces. Be willing to skip those tests at build-time, but not at runtime.
* The `builder` test gave warnings `/bin/sh: line 0: [: too many arguments` because a variable with spaces wasn't quoted correctly. These warnings were harmless, except that they meant `CFLAGS` wasn't actually being tested as intended.

With this branch, plus a Debian-specific patch adjusting to Debian having renamed `gtk-update-icon-cache` with a `-3.0` suffix for Gtk2/Gtk3 parallel-installability, the majority of the tests work. I'll open a separate issue for `test-builder`, which still requires unprivileged user namespaces: for the moment I'm skipping that one.